### PR TITLE
fix & improvement(society & esx): Correct getOnlinePlayers behaviour; update the old enumerate functions

### DIFF
--- a/[esx]/es_extended/client/functions.lua
+++ b/[esx]/es_extended/client/functions.lua
@@ -402,7 +402,6 @@ ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 end
 
 ESX.Game.SpawnLocalVehicle = function(vehicle, coords, heading, cb)
-	-- Why have 2 separate functions for this? Just call the other one with an extra param
 	ESX.Game.SpawnVehicle(vehicle, coords, heading, cb, false)
 end
 
@@ -413,20 +412,14 @@ ESX.Game.IsVehicleEmpty = function(vehicle)
 	return passengers == 0 and driverSeatFree
 end
 
-ESX.Game.GetObjects = function()
-	local objects = {}
-
-	for object in EnumerateObjects() do
-		table.insert(objects, object)
-	end
-
-	return objects
+ESX.Game.GetObjects = function() -- Leave the function for compatibility
+	return GetGamePool('CObject')
 end
 
 ESX.Game.GetPeds = function(onlyOtherPeds)
 	local peds, myPed = {}, ESX.PlayerData.ped
 
-	for ped in EnumeratePeds() do
+	for ped in GetGamePool('CPed') do
 		if ((onlyOtherPeds and ped ~= myPed) or not onlyOtherPeds) then
 			table.insert(peds, ped)
 		end
@@ -435,14 +428,8 @@ ESX.Game.GetPeds = function(onlyOtherPeds)
 	return peds
 end
 
-ESX.Game.GetVehicles = function()
-	local vehicles = {}
-
-	for vehicle in EnumerateVehicles() do
-		table.insert(vehicles, vehicle)
-	end
-
-	return vehicles
+ESX.Game.GetVehicles = function() -- Leave the function for compatibility
+	return GetGamePool('CVehicle')
 end
 
 ESX.Game.GetPlayers = function(onlyOtherPlayers, returnKeyValue, returnPeds)
@@ -463,13 +450,34 @@ ESX.Game.GetPlayers = function(onlyOtherPlayers, returnKeyValue, returnPeds)
 	return players
 end
 
-ESX.Game.GetClosestObject = function(coords, modelFilter) return ESX.Game.GetClosestEntity(ESX.Game.GetObjects(), false, coords, modelFilter) end
-ESX.Game.GetClosestPed = function(coords, modelFilter) return ESX.Game.GetClosestEntity(ESX.Game.GetPeds(true), false, coords, modelFilter) end
-ESX.Game.GetClosestPlayer = function(coords) return ESX.Game.GetClosestEntity(ESX.Game.GetPlayers(true, true), true, coords, nil) end
-ESX.Game.GetClosestVehicle = function(coords, modelFilter) return ESX.Game.GetClosestEntity(ESX.Game.GetVehicles(), false, coords, modelFilter) end
-ESX.Game.GetPlayersInArea = function(coords, maxDistance) return EnumerateEntitiesWithinDistance(ESX.Game.GetPlayers(true, true), true, coords, maxDistance) end
-ESX.Game.GetVehiclesInArea = function(coords, maxDistance) return EnumerateEntitiesWithinDistance(ESX.Game.GetVehicles(), false, coords, maxDistance) end
-ESX.Game.IsSpawnPointClear = function(coords, maxDistance) return #ESX.Game.GetVehiclesInArea(coords, maxDistance) == 0 end
+ESX.Game.GetClosestObject = function(coords, modelFilter)
+	return ESX.Game.GetClosestEntity(ESX.Game.GetObjects(), false, coords, modelFilter)
+end
+
+ESX.Game.GetClosestPed = function(coords, modelFilter)
+	return ESX.Game.GetClosestEntity(ESX.Game.GetPeds(true), false, coords, modelFilter)
+end
+
+ESX.Game.GetClosestPlayer = function(coords)
+	return ESX.Game.GetClosestEntity(ESX.Game.GetPlayers(true, true), true, coords, nil)
+end
+
+ESX.Game.GetClosestVehicle = function(coords, modelFilter)
+	return ESX.Game.GetClosestEntity(ESX.Game.GetVehicles(), false, coords, modelFilter)
+end
+
+ESX.Game.GetPlayersInArea = function(coords, maxDistance)
+	return EnumerateEntitiesWithinDistance(ESX.Game.GetPlayers(true, true), true, coords, maxDistance)
+end
+
+ESX.Game.GetVehiclesInArea = function(coords, maxDistance)
+	return EnumerateEntitiesWithinDistance(ESX.Game.GetVehicles(), false, coords, maxDistance)
+end
+
+ESX.Game.IsSpawnPointClear = function(coords, maxDistance)
+	return #ESX.Game.GetVehiclesInArea(coords, maxDistance) == 0
+end
+
 
 ESX.Game.GetClosestEntity = function(entities, isPlayerEntities, coords, modelFilter)
 	local closestEntity, closestEntityDistance, filteredEntities = -1, -1, nil

--- a/[esx_addons]/esx_society/server/main.lua
+++ b/[esx_addons]/esx_society/server/main.lua
@@ -316,9 +316,9 @@ ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job,
 	end
 end)
 
-local getOnlinePlayers, onlinePlayers = false, nil
+local getOnlinePlayers, onlinePlayers = false, {}
 ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
-	if getOnlinePlayers ~= true then -- Prevent multiple xPlayer loops from running in quick succession
+	if getOnlinePlayers == false and next(onlinePlayers) == nil then -- Prevent multiple xPlayer loops from running in quick succession
 		getOnlinePlayers, onlinePlayers = true, {}
 		
 		local xPlayers = ESX.GetExtendedPlayers()
@@ -330,9 +330,13 @@ ESX.RegisterServerCallback('esx_society:getOnlinePlayers', function(source, cb)
 				job = xPlayer.job
 			})
 		end
+		cb(onlinePlayers)
 		getOnlinePlayers = false
+		Citizen.Wait(1000) -- For the next second any extra requests will receive the cached list
+		onlinePlayers = {}
+		return
 	end
-	while getOnlinePlayers do Citizen.Wait(100) end -- Wait for the xPlayer loop to finish
+	while getOnlinePlayers do Citizen.Wait(10) end -- Wait for the xPlayer loop to finish
 	cb(onlinePlayers)
 end)
 


### PR DESCRIPTION
#### Society
In my initial commit for this I had mistakenly failed to reset the onlinePlayers table after the first callback.
In the changes I submitted for the compiled repo, I failed to stop multiple loops from running at once or in quick succession. 😞 

- Only one loop will run while the rest wait for it to finish (which is basically instant, anyway)
- Trigger the initial callback independently of the rest
- Wait 1 second before clearing the table


#### ESX
Kept the old functions but shouldn't be getting used, added GetGamePool