### PR TITLE
Add xPlayer.HowManyCanCarryItem("itemname")

### DIFF
--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -272,6 +272,13 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		return newWeight <= self.maxWeight
 	end
 
+	self.HowManyCanCarryItem = function(name)
+		local currentWeight, itemWeight = self.weight, ESX.Items[name].weight
+		local ItemAmount = math.floor((self.maxWeight - currentWeight)/itemWeight)
+
+		return ItemAmount
+	end
+
 	self.canSwapItem = function(firstItem, firstItemCount, testItem, testItemCount)
 		local firstItemObject = self.getInventoryItem(firstItem)
 		local testItemObject = self.getInventoryItem(testItem)


### PR DESCRIPTION
Returns how much of this item the player can get.
Less server request if used before a loop action.
Like
xPlayer.HowManyCanCarryItem("stone")
reminder example 10
Do the action to get the stone 10 times.

Old method
loop mine
And ask each time xPlayer.CanCarryItem("stone)