### PR TITLE
feat: setup basic support for ox inventory

### DIFF
--- a/[esx]/es_extended/client/common.lua
+++ b/[esx]/es_extended/client/common.lua
@@ -5,3 +5,7 @@ end)
 exports('getSharedObject', function()
 	return ESX
 end)
+
+if GetResourceState('ox_inventory') ~= 'missing' then
+	Config.OxInventory = true
+end

--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -107,26 +107,29 @@ end)
 
 AddEventHandler('esx:restoreLoadout', function()
 	ESX.SetPlayerData('ped', PlayerPedId())
-	local ammoTypes = {}
-	RemoveAllPedWeapons(ESX.PlayerData.ped, true)
 
-	for k,v in ipairs(ESX.PlayerData.loadout) do
-		local weaponName = v.name
-		local weaponHash = GetHashKey(weaponName)
+	if not Config.OxInventory then
+		local ammoTypes = {}
+		RemoveAllPedWeapons(ESX.PlayerData.ped, true)
 
-		GiveWeaponToPed(ESX.PlayerData.ped, weaponHash, 0, false, false)
-		SetPedWeaponTintIndex(ESX.PlayerData.ped, weaponHash, v.tintIndex)
+		for k,v in ipairs(ESX.PlayerData.loadout) do
+			local weaponName = v.name
+			local weaponHash = GetHashKey(weaponName)
 
-		local ammoType = GetPedAmmoTypeFromWeapon(ESX.PlayerData.ped, weaponHash)
+			GiveWeaponToPed(ESX.PlayerData.ped, weaponHash, 0, false, false)
+			SetPedWeaponTintIndex(ESX.PlayerData.ped, weaponHash, v.tintIndex)
 
-		for k2,v2 in ipairs(v.components) do
-			local componentHash = ESX.GetWeaponComponent(weaponName, v2).hash
-			GiveWeaponComponentToPed(ESX.PlayerData.ped, weaponHash, componentHash)
-		end
+			local ammoType = GetPedAmmoTypeFromWeapon(ESX.PlayerData.ped, weaponHash)
 
-		if not ammoTypes[ammoType] then
-			AddAmmoToPed(ESX.PlayerData.ped, weaponHash, v.ammo)
-			ammoTypes[ammoType] = true
+			for k2,v2 in ipairs(v.components) do
+				local componentHash = ESX.GetWeaponComponent(weaponName, v2).hash
+				GiveWeaponComponentToPed(ESX.PlayerData.ped, weaponHash, componentHash)
+			end
+
+			if not ammoTypes[ammoType] then
+				AddAmmoToPed(ESX.PlayerData.ped, weaponHash, v.ammo)
+				ammoTypes[ammoType] = true
+			end
 		end
 	end
 end)
@@ -139,6 +142,7 @@ AddEventHandler('esx:setAccountMoney', function(account)
 			break
 		end
 	end
+
 	ESX.SetPlayerData('accounts', ESX.PlayerData.accounts)
 
 	if Config.EnableHud then
@@ -148,77 +152,79 @@ AddEventHandler('esx:setAccountMoney', function(account)
 	end
 end)
 
-RegisterNetEvent('esx:addInventoryItem')
-AddEventHandler('esx:addInventoryItem', function(item, count, showNotification)
-	for k,v in ipairs(ESX.PlayerData.inventory) do
-		if v.name == item then
-			ESX.UI.ShowInventoryItemNotification(true, v.label, count - v.count)
-			ESX.PlayerData.inventory[k].count = count
-			break
+if not Config.OxInventory then
+	RegisterNetEvent('esx:addInventoryItem')
+	AddEventHandler('esx:addInventoryItem', function(item, count, showNotification)
+		for k,v in ipairs(ESX.PlayerData.inventory) do
+			if v.name == item then
+				ESX.UI.ShowInventoryItemNotification(true, v.label, count - v.count)
+				ESX.PlayerData.inventory[k].count = count
+				break
+			end
 		end
-	end
 
-	if showNotification then
-		ESX.UI.ShowInventoryItemNotification(true, item, count)
-	end
-
-	if ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
-		ESX.ShowInventory()
-	end
-end)
-
-RegisterNetEvent('esx:removeInventoryItem')
-AddEventHandler('esx:removeInventoryItem', function(item, count, showNotification)
-	for k,v in ipairs(ESX.PlayerData.inventory) do
-		if v.name == item then
-			ESX.UI.ShowInventoryItemNotification(false, v.label, v.count - count)
-			ESX.PlayerData.inventory[k].count = count
-			break
+		if showNotification then
+			ESX.UI.ShowInventoryItemNotification(true, item, count)
 		end
-	end
 
-	if showNotification then
-		ESX.UI.ShowInventoryItemNotification(false, item, count)
-	end
+		if ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
+			ESX.ShowInventory()
+		end
+	end)
 
-	if ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
-		ESX.ShowInventory()
-	end
-end)
+	RegisterNetEvent('esx:removeInventoryItem')
+	AddEventHandler('esx:removeInventoryItem', function(item, count, showNotification)
+		for k,v in ipairs(ESX.PlayerData.inventory) do
+			if v.name == item then
+				ESX.UI.ShowInventoryItemNotification(false, v.label, v.count - count)
+				ESX.PlayerData.inventory[k].count = count
+				break
+			end
+		end
 
-RegisterNetEvent('esx:addWeapon')
-AddEventHandler('esx:addWeapon', function(weapon, ammo)
-	GiveWeaponToPed(ESX.PlayerData.ped, GetHashKey(weapon), ammo, false, false)
-end)
+		if showNotification then
+			ESX.UI.ShowInventoryItemNotification(false, item, count)
+		end
 
-RegisterNetEvent('esx:addWeaponComponent')
-AddEventHandler('esx:addWeaponComponent', function(weapon, weaponComponent)
-	local componentHash = ESX.GetWeaponComponent(weapon, weaponComponent).hash
-	GiveWeaponComponentToPed(ESX.PlayerData.ped, GetHashKey(weapon), componentHash)
-end)
+		if ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
+			ESX.ShowInventory()
+		end
+	end)
 
-RegisterNetEvent('esx:setWeaponAmmo')
-AddEventHandler('esx:setWeaponAmmo', function(weapon, weaponAmmo)
-	SetPedAmmo(ESX.PlayerData.ped, GetHashKey(weapon), weaponAmmo)
-end)
+	RegisterNetEvent('esx:addWeapon')
+	AddEventHandler('esx:addWeapon', function(weapon, ammo)
+		GiveWeaponToPed(ESX.PlayerData.ped, GetHashKey(weapon), ammo, false, false)
+	end)
 
-RegisterNetEvent('esx:setWeaponTint')
-AddEventHandler('esx:setWeaponTint', function(weapon, weaponTintIndex)
-	SetPedWeaponTintIndex(ESX.PlayerData.ped, GetHashKey(weapon), weaponTintIndex)
-end)
+	RegisterNetEvent('esx:addWeaponComponent')
+	AddEventHandler('esx:addWeaponComponent', function(weapon, weaponComponent)
+		local componentHash = ESX.GetWeaponComponent(weapon, weaponComponent).hash
+		GiveWeaponComponentToPed(ESX.PlayerData.ped, GetHashKey(weapon), componentHash)
+	end)
 
-RegisterNetEvent('esx:removeWeapon')
-AddEventHandler('esx:removeWeapon', function(weapon)
-	local playerPed = ESX.PlayerData.ped
-	RemoveWeaponFromPed(ESX.PlayerData.ped, GetHashKey(weapon))
-	SetPedAmmo(ESX.PlayerData.ped, GetHashKey(weapon), 0)
-end)
+	RegisterNetEvent('esx:setWeaponAmmo')
+	AddEventHandler('esx:setWeaponAmmo', function(weapon, weaponAmmo)
+		SetPedAmmo(ESX.PlayerData.ped, GetHashKey(weapon), weaponAmmo)
+	end)
 
-RegisterNetEvent('esx:removeWeaponComponent')
-AddEventHandler('esx:removeWeaponComponent', function(weapon, weaponComponent)
-	local componentHash = ESX.GetWeaponComponent(weapon, weaponComponent).hash
-	RemoveWeaponComponentFromPed(ESX.PlayerData.ped, GetHashKey(weapon), componentHash)
-end)
+	RegisterNetEvent('esx:setWeaponTint')
+	AddEventHandler('esx:setWeaponTint', function(weapon, weaponTintIndex)
+		SetPedWeaponTintIndex(ESX.PlayerData.ped, GetHashKey(weapon), weaponTintIndex)
+	end)
+
+	RegisterNetEvent('esx:removeWeapon')
+	AddEventHandler('esx:removeWeapon', function(weapon)
+		local playerPed = ESX.PlayerData.ped
+		RemoveWeaponFromPed(ESX.PlayerData.ped, GetHashKey(weapon))
+		SetPedAmmo(ESX.PlayerData.ped, GetHashKey(weapon), 0)
+	end)
+
+	RegisterNetEvent('esx:removeWeaponComponent')
+	AddEventHandler('esx:removeWeaponComponent', function(weapon, weaponComponent)
+		local componentHash = ESX.GetWeaponComponent(weapon, weaponComponent).hash
+		RemoveWeaponComponentFromPed(ESX.PlayerData.ped, GetHashKey(weapon), componentHash)
+	end)
+end
 
 RegisterNetEvent('esx:teleport')
 AddEventHandler('esx:teleport', function(coords)
@@ -257,45 +263,47 @@ AddEventHandler('esx:spawnVehicle', function(vehicle)
 	end)
 end)
 
-RegisterNetEvent('esx:createPickup')
-AddEventHandler('esx:createPickup', function(pickupId, label, coords, type, name, components, tintIndex)
-	local function setObjectProperties(object)
-		SetEntityAsMissionEntity(object, true, false)
-		PlaceObjectOnGroundProperly(object)
-		FreezeEntityPosition(object, true)
-		SetEntityCollision(object, false, true)
+if not Config.OxInventory then
+	RegisterNetEvent('esx:createPickup')
+	AddEventHandler('esx:createPickup', function(pickupId, label, coords, type, name, components, tintIndex)
+		local function setObjectProperties(object)
+			SetEntityAsMissionEntity(object, true, false)
+			PlaceObjectOnGroundProperly(object)
+			FreezeEntityPosition(object, true)
+			SetEntityCollision(object, false, true)
 
-		pickups[pickupId] = {
-			obj = object,
-			label = label,
-			inRange = false,
-			coords = vector3(coords.x, coords.y, coords.z)
-		}
-	end
-
-	if type == 'item_weapon' then
-		local weaponHash = GetHashKey(name)
-		ESX.Streaming.RequestWeaponAsset(weaponHash)
-		local pickupObject = CreateWeaponObject(weaponHash, 50, coords.x, coords.y, coords.z, true, 1.0, 0)
-		SetWeaponObjectTintIndex(pickupObject, tintIndex)
-
-		for k,v in ipairs(components) do
-			local component = ESX.GetWeaponComponent(name, v)
-			GiveWeaponComponentToWeaponObject(pickupObject, component.hash)
+			pickups[pickupId] = {
+				obj = object,
+				label = label,
+				inRange = false,
+				coords = vector3(coords.x, coords.y, coords.z)
+			}
 		end
 
-		setObjectProperties(pickupObject)
-	else
-		ESX.Game.SpawnLocalObject('prop_money_bag_01', coords, setObjectProperties)
-	end
-end)
+		if type == 'item_weapon' then
+			local weaponHash = GetHashKey(name)
+			ESX.Streaming.RequestWeaponAsset(weaponHash)
+			local pickupObject = CreateWeaponObject(weaponHash, 50, coords.x, coords.y, coords.z, true, 1.0, 0)
+			SetWeaponObjectTintIndex(pickupObject, tintIndex)
 
-RegisterNetEvent('esx:createMissingPickups')
-AddEventHandler('esx:createMissingPickups', function(missingPickups)
-	for pickupId, pickup in pairs(missingPickups) do
-		TriggerEvent('esx:createPickup', pickupId, pickup.label, pickup.coords, pickup.type, pickup.name, pickup.components, pickup.tintIndex)
-	end
-end)
+			for k,v in ipairs(components) do
+				local component = ESX.GetWeaponComponent(name, v)
+				GiveWeaponComponentToWeaponObject(pickupObject, component.hash)
+			end
+
+			setObjectProperties(pickupObject)
+		else
+			ESX.Game.SpawnLocalObject('prop_money_bag_01', coords, setObjectProperties)
+		end
+	end)
+
+	RegisterNetEvent('esx:createMissingPickups')
+	AddEventHandler('esx:createMissingPickups', function(missingPickups)
+		for pickupId, pickup in pairs(missingPickups) do
+			TriggerEvent('esx:createPickup', pickupId, pickup.label, pickup.coords, pickup.type, pickup.name, pickup.components, pickup.tintIndex)
+		end
+	end)
+end
 
 RegisterNetEvent('esx:registerSuggestions')
 AddEventHandler('esx:registerSuggestions', function(registeredCommands)
@@ -306,13 +314,15 @@ AddEventHandler('esx:registerSuggestions', function(registeredCommands)
 	end
 end)
 
-RegisterNetEvent('esx:removePickup')
-AddEventHandler('esx:removePickup', function(pickupId)
-	if pickups[pickupId] and pickups[pickupId].obj then
-		ESX.Game.DeleteObject(pickups[pickupId].obj)
-		pickups[pickupId] = nil
-	end
-end)
+if not Config.OxInventory then
+	RegisterNetEvent('esx:removePickup')
+	AddEventHandler('esx:removePickup', function(pickupId)
+		if pickups[pickupId] and pickups[pickupId].obj then
+			ESX.Game.DeleteObject(pickups[pickupId].obj)
+			pickups[pickupId] = nil
+		end
+	end)
+end
 
 RegisterNetEvent('esx:deleteVehicle')
 AddEventHandler('esx:deleteVehicle', function(radius)
@@ -378,37 +388,39 @@ if Config.EnableHud then
 end
 
 function StartServerSyncLoops()
-	-- keep track of ammo
-	CreateThread(function()
-		local currentWeapon = {timer=0}
-		while ESX.PlayerLoaded do
-			local sleep = 5
+	if not Config.OxInventory then
+		-- keep track of ammo
+		CreateThread(function()
+			local currentWeapon = {timer=0}
+			while ESX.PlayerLoaded do
+				local sleep = 5
 
-			if currentWeapon.timer == sleep then
-				local ammoCount = GetAmmoInPedWeapon(ESX.PlayerData.ped, currentWeapon.hash)
-				TriggerServerEvent('esx:updateWeaponAmmo', currentWeapon.name, ammoCount)
-				currentWeapon.timer = 0
-			elseif currentWeapon.timer > sleep then
-				currentWeapon.timer = currentWeapon.timer - sleep
-			end
-
-			if IsPedArmed(ESX.PlayerData.ped, 4) then
-				if IsPedShooting(ESX.PlayerData.ped) then
-					local _,weaponHash = GetCurrentPedWeapon(ESX.PlayerData.ped, true)
-					local weapon = ESX.GetWeaponFromHash(weaponHash)
-
-					if weapon then
-						currentWeapon.name = weapon.name
-						currentWeapon.hash = weaponHash
-						currentWeapon.timer = 100 * sleep
-					end
+				if currentWeapon.timer == sleep then
+					local ammoCount = GetAmmoInPedWeapon(ESX.PlayerData.ped, currentWeapon.hash)
+					TriggerServerEvent('esx:updateWeaponAmmo', currentWeapon.name, ammoCount)
+					currentWeapon.timer = 0
+				elseif currentWeapon.timer > sleep then
+					currentWeapon.timer = currentWeapon.timer - sleep
 				end
-			else
-				sleep = 200
+
+				if IsPedArmed(ESX.PlayerData.ped, 4) then
+					if IsPedShooting(ESX.PlayerData.ped) then
+						local _,weaponHash = GetCurrentPedWeapon(ESX.PlayerData.ped, true)
+						local weapon = ESX.GetWeaponFromHash(weaponHash)
+
+						if weapon then
+							currentWeapon.name = weapon.name
+							currentWeapon.hash = weaponHash
+							currentWeapon.timer = 100 * sleep
+						end
+					end
+				else
+					sleep = 200
+				end
+				Wait(sleep)
 			end
-			Wait(sleep)
-		end
-	end)
+		end)
+	end
 
 	-- sync current player coords with server
 	CreateThread(function()
@@ -434,7 +446,7 @@ function StartServerSyncLoops()
 	end)
 end
 
-if Config.EnableDefaultInventory then
+if not Config.OxInventory and Config.EnableDefaultInventory then
 	RegisterCommand('showinv', function()
 		if not ESX.PlayerData.dead and not ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
 			ESX.ShowInventory()
@@ -450,52 +462,54 @@ if not Config.EnableWantedLevel then
 	SetMaxWantedLevel(0)
 end
 
-CreateThread(function()
-	while true do
-		Wait(0)
-		local playerCoords, letSleep = GetEntityCoords(ESX.PlayerData.ped), true
-		local closestPlayer, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
+if not Config.OxInventory then
+	CreateThread(function()
+		while true do
+			Wait(0)
+			local playerCoords, letSleep = GetEntityCoords(ESX.PlayerData.ped), true
+			local closestPlayer, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
 
-		for pickupId,pickup in pairs(pickups) do
-			local distance = #(playerCoords - pickup.coords)
+			for pickupId,pickup in pairs(pickups) do
+				local distance = #(playerCoords - pickup.coords)
 
-			if distance < 5 then
-				local label = pickup.label
-				letSleep = false
+				if distance < 5 then
+					local label = pickup.label
+					letSleep = false
 
-				if distance < 1 then
-					if IsControlJustReleased(0, 38) then
-						if IsPedOnFoot(ESX.PlayerData.ped) and (closestDistance == -1 or closestDistance > 3) and not pickup.inRange then
-							pickup.inRange = true
+					if distance < 1 then
+						if IsControlJustReleased(0, 38) then
+							if IsPedOnFoot(ESX.PlayerData.ped) and (closestDistance == -1 or closestDistance > 3) and not pickup.inRange then
+								pickup.inRange = true
 
-							local dict, anim = 'weapons@first_person@aim_rng@generic@projectile@sticky_bomb@', 'plant_floor'
-							ESX.Streaming.RequestAnimDict(dict)
-							TaskPlayAnim(ESX.PlayerData.ped, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
-							Wait(1000)
+								local dict, anim = 'weapons@first_person@aim_rng@generic@projectile@sticky_bomb@', 'plant_floor'
+								ESX.Streaming.RequestAnimDict(dict)
+								TaskPlayAnim(ESX.PlayerData.ped, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
+								Wait(1000)
 
-							TriggerServerEvent('esx:onPickup', pickupId)
-							PlaySoundFrontend(-1, 'PICK_UP', 'HUD_FRONTEND_DEFAULT_SOUNDSET', false)
+								TriggerServerEvent('esx:onPickup', pickupId)
+								PlaySoundFrontend(-1, 'PICK_UP', 'HUD_FRONTEND_DEFAULT_SOUNDSET', false)
+							end
 						end
+
+						label = ('%s~n~%s'):format(label, _U('threw_pickup_prompt'))
 					end
 
-					label = ('%s~n~%s'):format(label, _U('threw_pickup_prompt'))
+					ESX.Game.Utils.DrawText3D({
+						x = pickup.coords.x,
+						y = pickup.coords.y,
+						z = pickup.coords.z + 0.25
+					}, label, 1.2, 1)
+				elseif pickup.inRange then
+					pickup.inRange = false
 				end
+			end
 
-				ESX.Game.Utils.DrawText3D({
-					x = pickup.coords.x,
-					y = pickup.coords.y,
-					z = pickup.coords.z + 0.25
-				}, label, 1.2, 1)
-			elseif pickup.inRange then
-				pickup.inRange = false
+			if letSleep then
+				Wait(500)
 			end
 		end
-
-		if letSleep then
-			Wait(500)
-		end
-	end
-end)
+	end)
+end
 
 ----- Admin commnads from esx_adminplus
 

--- a/[esx]/es_extended/server/commands.lua
+++ b/[esx]/es_extended/server/commands.lua
@@ -56,47 +56,49 @@ end, true, {help = _U('command_giveaccountmoney'), validate = true, arguments = 
 	{name = 'amount', help = _U('command_giveaccountmoney_amount'), type = 'number'}
 }})
 
-ESX.RegisterCommand('giveitem', 'admin', function(xPlayer, args, showError)
-	args.playerId.addInventoryItem(args.item, args.count)
-end, true, {help = _U('command_giveitem'), validate = true, arguments = {
-	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
-	{name = 'item', help = _U('command_giveitem_item'), type = 'item'},
-	{name = 'count', help = _U('command_giveitem_count'), type = 'number'}
-}})
+if not Config.OxInventory then
+	ESX.RegisterCommand('giveitem', 'admin', function(xPlayer, args, showError)
+		args.playerId.addInventoryItem(args.item, args.count)
+	end, true, {help = _U('command_giveitem'), validate = true, arguments = {
+		{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
+		{name = 'item', help = _U('command_giveitem_item'), type = 'item'},
+		{name = 'count', help = _U('command_giveitem_count'), type = 'number'}
+	}})
 
-ESX.RegisterCommand('giveweapon', 'admin', function(xPlayer, args, showError)
-	if args.playerId.hasWeapon(args.weapon) then
-		showError(_U('command_giveweapon_hasalready'))
-	else
-		args.playerId.addWeapon(args.weapon, args.ammo)
-	end
-end, true, {help = _U('command_giveweapon'), validate = true, arguments = {
-	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
-	{name = 'weapon', help = _U('command_giveweapon_weapon'), type = 'weapon'},
-	{name = 'ammo', help = _U('command_giveweapon_ammo'), type = 'number'}
-}})
+	ESX.RegisterCommand('giveweapon', 'admin', function(xPlayer, args, showError)
+		if args.playerId.hasWeapon(args.weapon) then
+			showError(_U('command_giveweapon_hasalready'))
+		else
+			args.playerId.addWeapon(args.weapon, args.ammo)
+		end
+	end, true, {help = _U('command_giveweapon'), validate = true, arguments = {
+		{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
+		{name = 'weapon', help = _U('command_giveweapon_weapon'), type = 'weapon'},
+		{name = 'ammo', help = _U('command_giveweapon_ammo'), type = 'number'}
+	}})
 
-ESX.RegisterCommand('giveweaponcomponent', 'admin', function(xPlayer, args, showError)
-	if args.playerId.hasWeapon(args.weaponName) then
-		local component = ESX.GetWeaponComponent(args.weaponName, args.componentName)
+	ESX.RegisterCommand('giveweaponcomponent', 'admin', function(xPlayer, args, showError)
+		if args.playerId.hasWeapon(args.weaponName) then
+			local component = ESX.GetWeaponComponent(args.weaponName, args.componentName)
 
-		if component then
-			if args.playerId.hasWeaponComponent(args.weaponName, args.componentName) then
-				showError(_U('command_giveweaponcomponent_hasalready'))
+			if component then
+				if args.playerId.hasWeaponComponent(args.weaponName, args.componentName) then
+					showError(_U('command_giveweaponcomponent_hasalready'))
+				else
+					args.playerId.addWeaponComponent(args.weaponName, args.componentName)
+				end
 			else
-				args.playerId.addWeaponComponent(args.weaponName, args.componentName)
+				showError(_U('command_giveweaponcomponent_invalid'))
 			end
 		else
-			showError(_U('command_giveweaponcomponent_invalid'))
+			showError(_U('command_giveweaponcomponent_missingweapon'))
 		end
-	else
-		showError(_U('command_giveweaponcomponent_missingweapon'))
-	end
-end, true, {help = _U('command_giveweaponcomponent'), validate = true, arguments = {
-	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
-	{name = 'weaponName', help = _U('command_giveweapon_weapon'), type = 'weapon'},
-	{name = 'componentName', help = _U('command_giveweaponcomponent_component'), type = 'string'}
-}})
+	end, true, {help = _U('command_giveweaponcomponent'), validate = true, arguments = {
+		{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'},
+		{name = 'weaponName', help = _U('command_giveweapon_weapon'), type = 'weapon'},
+		{name = 'componentName', help = _U('command_giveweaponcomponent_component'), type = 'string'}
+	}})
+end
 
 ESX.RegisterCommand({'clear', 'cls'}, 'user', function(xPlayer, args, showError)
 	xPlayer.triggerEvent('chat:clear')
@@ -106,23 +108,25 @@ ESX.RegisterCommand({'clearall', 'clsall'}, 'admin', function(xPlayer, args, sho
 	TriggerClientEvent('chat:clear', -1)
 end, false, {help = _U('command_clearall')})
 
-ESX.RegisterCommand('clearinventory', 'admin', function(xPlayer, args, showError)
-	for k,v in ipairs(args.playerId.inventory) do
-		if v.count > 0 then
-			args.playerId.setInventoryItem(v.name, 0)
+if not Config.OxInventory then
+	ESX.RegisterCommand('clearinventory', 'admin', function(xPlayer, args, showError)
+		for k,v in ipairs(args.playerId.inventory) do
+			if v.count > 0 then
+				args.playerId.setInventoryItem(v.name, 0)
+			end
 		end
-	end
-end, true, {help = _U('command_clearinventory'), validate = true, arguments = {
-	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}
-}})
+	end, true, {help = _U('command_clearinventory'), validate = true, arguments = {
+		{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}
+	}})
 
-ESX.RegisterCommand('clearloadout', 'admin', function(xPlayer, args, showError)
-	for i=#args.playerId.loadout, 1, -1 do
-		args.playerId.removeWeapon(args.playerId.loadout[i].name)
-	end
-end, true, {help = _U('command_clearloadout'), validate = true, arguments = {
-	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}
-}})
+	ESX.RegisterCommand('clearloadout', 'admin', function(xPlayer, args, showError)
+		for i=#args.playerId.loadout, 1, -1 do
+			args.playerId.removeWeapon(args.playerId.loadout[i].name)
+		end
+	end, true, {help = _U('command_clearloadout'), validate = true, arguments = {
+		{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}
+	}})
+end
 
 ESX.RegisterCommand('setgroup', 'admin', function(xPlayer, args, showError)
 	if not args.playerId then args.playerId = xPlayer.source end

--- a/[esx]/es_extended/server/common.lua
+++ b/[esx]/es_extended/server/common.lua
@@ -19,6 +19,12 @@ exports('getSharedObject', function()
 	return ESX
 end)
 
+if GetResourceState('ox_inventory') ~= 'missing' then
+	Config.OxInventory = true
+	SetConvarReplicated('inventory:framework', 'esx')
+	SetConvarReplicated('inventory:weight', Config.MaxWeight * 1000)
+end
+
 local function StartDBSync()
 	CreateThread(function()
 		while true do
@@ -29,14 +35,28 @@ local function StartDBSync()
 end
 
 MySQL.ready(function()
-	local items = MySQL.query.await('SELECT * FROM items')
-	for k, v in ipairs(items) do
-		ESX.Items[v.name] = {
-			label = v.label,
-			weight = v.weight,
-			rare = v.rare,
-			canRemove = v.can_remove
-		}
+	if not Config.OxInventory then
+		local items = MySQL.query.await('SELECT * FROM items')
+		for k, v in ipairs(items) do
+			ESX.Items[v.name] = {
+				label = v.label,
+				weight = v.weight,
+				rare = v.rare,
+				canRemove = v.can_remove
+			}
+		end
+	else
+		TriggerEvent('__cfx_export_ox_inventory_Items', function(ref)
+			if ref then
+				ESX.Items = ref()
+			end
+		end)
+
+		AddEventHandler('ox_inventory:itemList', function(items)
+			ESX.Items = items
+		end)
+
+		while not next(ESX.Items) do Wait(0) end
 	end
 
 	local Jobs = {}

--- a/[esx]/es_extended/server/functions.lua
+++ b/[esx]/es_extended/server/functions.lua
@@ -258,13 +258,18 @@ function ESX.RegisterUsableItem(item, cb)
 	Core.UsableItemsCallbacks[item] = cb
 end
 
-function ESX.UseItem(source, item)
-	Core.UsableItemsCallbacks[item](source, item)
+function ESX.UseItem(source, item, data)
+	Core.UsableItemsCallbacks[item](source, item, data)
 end
 
 function ESX.GetItemLabel(item)
 	if ESX.Items[item] then
 		return ESX.Items[item].label
+	end
+
+	if Config.OxInventory then
+		item = exports.ox_inventory:Items(item)
+		if item then return item.label end
 	end
 end
 
@@ -280,24 +285,26 @@ function ESX.GetUsableItems()
 	return Usables
 end
 
-function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex)
-	local pickupId = (Core.PickupId == 65635 and 0 or Core.PickupId + 1)
-	local xPlayer = ESX.GetPlayerFromId(playerId)
-	local coords = xPlayer.getCoords()
+if not Config.OxInventory then
+	function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex)
+		local pickupId = (Core.PickupId == 65635 and 0 or Core.PickupId + 1)
+		local xPlayer = ESX.GetPlayerFromId(playerId)
+		local coords = xPlayer.getCoords()
 
-	Core.Pickups[pickupId] = {
-		type = type, name = name,
-		count = count, label = label,
-		coords = coords
-	}
+		Core.Pickups[pickupId] = {
+			type = type, name = name,
+			count = count, label = label,
+			coords = coords
+		}
 
-	if type == 'item_weapon' then
-		Core.Pickups[pickupId].components = components
-		Core.Pickups[pickupId].tintIndex = tintIndex
+		if type == 'item_weapon' then
+			Core.Pickups[pickupId].components = components
+			Core.Pickups[pickupId].tintIndex = tintIndex
+		end
+
+		TriggerClientEvent('esx:createPickup', -1, pickupId, label, coords, type, name, components, tintIndex)
+		Core.PickupId = pickupId
 	end
-
-	TriggerClientEvent('esx:createPickup', -1, pickupId, label, coords, type, name, components, tintIndex)
-	Core.PickupId = pickupId
 end
 
 function ESX.DoesJobExist(job, grade)
@@ -318,6 +325,7 @@ function Core.IsPlayerAdmin(playerId)
 	end
 
 	local xPlayer = ESX.GetPlayerFromId(playerId)
+
 	if xPlayer then
 		if xPlayer.group == 'admin' then
 			return true

--- a/[esx]/es_extended/server/main.lua
+++ b/[esx]/es_extended/server/main.lua
@@ -164,38 +164,46 @@ function loadESXPlayer(identifier, playerId, isNew)
 	if gradeObject.skin_female then userData.job.skin_female = json.decode(gradeObject.skin_female) end
 
 	-- Inventory
-	if result.inventory and result.inventory ~= '' then
-		local inventory = json.decode(result.inventory)
+	if not Config.OxInventory then
+		if result.inventory and result.inventory ~= '' then
+			local inventory = json.decode(result.inventory)
 
-		for name,count in pairs(inventory) do
-			local item = ESX.Items[name]
+			for name,count in pairs(inventory) do
+				local item = ESX.Items[name]
 
-			if item then
-				foundItems[name] = count
-			else
-				print(('[^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
+				if item then
+					foundItems[name] = count
+				else
+					print(('[^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
+				end
 			end
 		end
+
+		for name,item in pairs(ESX.Items) do
+			local count = foundItems[name] or 0
+			if count > 0 then userData.weight = userData.weight + (item.weight * count) end
+
+			table.insert(userData.inventory, {
+				name = name,
+				count = count,
+				label = item.label,
+				weight = item.weight,
+				usable = Core.UsableItemsCallbacks[name] ~= nil,
+				rare = item.rare,
+				canRemove = item.canRemove
+			})
+		end
+
+		table.sort(userData.inventory, function(a, b)
+			return a.label < b.label
+		end)
+	else
+		if result.inventory and result.inventory ~= '' then
+			userData.inventory = json.decode(result.inventory)
+		else
+			userData.inventory = {}
+		end
 	end
-
-	for name,item in pairs(ESX.Items) do
-		local count = foundItems[name] or 0
-		if count > 0 then userData.weight = userData.weight + (item.weight * count) end
-
-		table.insert(userData.inventory, {
-			name = name,
-			count = count,
-			label = item.label,
-			weight = item.weight,
-			usable = Core.UsableItemsCallbacks[name] ~= nil,
-			rare = item.rare,
-			canRemove = item.canRemove
-		})
-	end
-
-	table.sort(userData.inventory, function(a, b)
-		return a.label < b.label
-	end)
 
 	-- Group
 	if result.group then
@@ -209,23 +217,25 @@ function loadESXPlayer(identifier, playerId, isNew)
 	end
 
 	-- Loadout
-	if result.loadout and result.loadout ~= '' then
-		local loadout = json.decode(result.loadout)
+	if not Config.OxInventory then
+		if result.loadout and result.loadout ~= '' then
+			local loadout = json.decode(result.loadout)
 
-		for name,weapon in pairs(loadout) do
-			local label = ESX.GetWeaponLabel(name)
+			for name,weapon in pairs(loadout) do
+				local label = ESX.GetWeaponLabel(name)
 
-			if label then
-				if not weapon.components then weapon.components = {} end
-				if not weapon.tintIndex then weapon.tintIndex = 0 end
+				if label then
+					if not weapon.components then weapon.components = {} end
+					if not weapon.tintIndex then weapon.tintIndex = 0 end
 
-				table.insert(userData.loadout, {
-					name = name,
-					ammo = weapon.ammo,
-					label = label,
-					components = weapon.components,
-					tintIndex = weapon.tintIndex
-				})
+					table.insert(userData.loadout, {
+						name = name,
+						ammo = weapon.ammo,
+						label = label,
+						components = weapon.components,
+						tintIndex = weapon.tintIndex
+					})
+				end
 			end
 		end
 	end
@@ -280,7 +290,12 @@ function loadESXPlayer(identifier, playerId, isNew)
 		dead = false
 	}, isNew, userData.skin)
 
-	xPlayer.triggerEvent('esx:createMissingPickups', Core.Pickups)
+	if not Config.OxInventory then
+		xPlayer.triggerEvent('esx:createMissingPickups', Core.Pickups)
+	else
+		exports.ox_inventory:setPlayerInventory(xPlayer, userData.inventory)
+	end
+
 	xPlayer.triggerEvent('esx:registerSuggestions', Core.RegisteredCommands)
 	print(('[^2INFO^0] Player ^5"%s" ^0has connected to the server. ID: ^5%s^7'):format(xPlayer.getName(), playerId))
 end
@@ -329,203 +344,206 @@ AddEventHandler('esx:updateCoords', function(coords)
 	end
 end)
 
-RegisterNetEvent('esx:updateWeaponAmmo')
-AddEventHandler('esx:updateWeaponAmmo', function(weaponName, ammoCount)
-	local xPlayer = ESX.GetPlayerFromId(source)
+if not Config.OxInventory then
+	RegisterNetEvent('esx:updateWeaponAmmo')
+	AddEventHandler('esx:updateWeaponAmmo', function(weaponName, ammoCount)
+		local xPlayer = ESX.GetPlayerFromId(source)
 
-	if xPlayer then
-		xPlayer.updateWeaponAmmo(weaponName, ammoCount)
-	end
-end)
-
-RegisterNetEvent('esx:giveInventoryItem')
-AddEventHandler('esx:giveInventoryItem', function(target, type, itemName, itemCount)
-	local playerId = source
-	local sourceXPlayer = ESX.GetPlayerFromId(playerId)
-	local targetXPlayer = ESX.GetPlayerFromId(target)
-
-	if type == 'item_standard' then
-		local sourceItem = sourceXPlayer.getInventoryItem(itemName)
-
-		if itemCount > 0 and sourceItem.count >= itemCount then
-			if targetXPlayer.canCarryItem(itemName, itemCount) then
-				sourceXPlayer.removeInventoryItem(itemName, itemCount)
-				targetXPlayer.addInventoryItem   (itemName, itemCount)
-
-				sourceXPlayer.showNotification(_U('gave_item', itemCount, sourceItem.label, targetXPlayer.name))
-				targetXPlayer.showNotification(_U('received_item', itemCount, sourceItem.label, sourceXPlayer.name))
-			else
-				sourceXPlayer.showNotification(_U('ex_inv_lim', targetXPlayer.name))
-			end
-		else
-			sourceXPlayer.showNotification(_U('imp_invalid_quantity'))
+		if xPlayer then
+			xPlayer.updateWeaponAmmo(weaponName, ammoCount)
 		end
-	elseif type == 'item_account' then
-		if itemCount > 0 and sourceXPlayer.getAccount(itemName).money >= itemCount then
-			sourceXPlayer.removeAccountMoney(itemName, itemCount)
-			targetXPlayer.addAccountMoney   (itemName, itemCount)
+	end)
 
-			sourceXPlayer.showNotification(_U('gave_account_money', ESX.Math.GroupDigits(itemCount), Config.Accounts[itemName], targetXPlayer.name))
-			targetXPlayer.showNotification(_U('received_account_money', ESX.Math.GroupDigits(itemCount), Config.Accounts[itemName], sourceXPlayer.name))
-		else
-			sourceXPlayer.showNotification(_U('imp_invalid_amount'))
-		end
-	elseif type == 'item_weapon' then
-		if sourceXPlayer.hasWeapon(itemName) then
-			local weaponLabel = ESX.GetWeaponLabel(itemName)
+	RegisterNetEvent('esx:giveInventoryItem')
+	AddEventHandler('esx:giveInventoryItem', function(target, type, itemName, itemCount)
+		local playerId = source
+		local sourceXPlayer = ESX.GetPlayerFromId(playerId)
+		local targetXPlayer = ESX.GetPlayerFromId(target)
 
-			if not targetXPlayer.hasWeapon(itemName) then
-				local _, weapon = sourceXPlayer.getWeapon(itemName)
-				local _, weaponObject = ESX.GetWeapon(itemName)
-				itemCount = weapon.ammo
+		if type == 'item_standard' then
+			local sourceItem = sourceXPlayer.getInventoryItem(itemName)
 
-				sourceXPlayer.removeWeapon(itemName)
-				targetXPlayer.addWeapon(itemName, itemCount)
+			if itemCount > 0 and sourceItem.count >= itemCount then
+				if targetXPlayer.canCarryItem(itemName, itemCount) then
+					sourceXPlayer.removeInventoryItem(itemName, itemCount)
+					targetXPlayer.addInventoryItem   (itemName, itemCount)
 
-				if weaponObject.ammo and itemCount > 0 then
-					local ammoLabel = weaponObject.ammo.label
-					sourceXPlayer.showNotification(_U('gave_weapon_withammo', weaponLabel, itemCount, ammoLabel, targetXPlayer.name))
-					targetXPlayer.showNotification(_U('received_weapon_withammo', weaponLabel, itemCount, ammoLabel, sourceXPlayer.name))
+					sourceXPlayer.showNotification(_U('gave_item', itemCount, sourceItem.label, targetXPlayer.name))
+					targetXPlayer.showNotification(_U('received_item', itemCount, sourceItem.label, sourceXPlayer.name))
 				else
-					sourceXPlayer.showNotification(_U('gave_weapon', weaponLabel, targetXPlayer.name))
-					targetXPlayer.showNotification(_U('received_weapon', weaponLabel, sourceXPlayer.name))
+					sourceXPlayer.showNotification(_U('ex_inv_lim', targetXPlayer.name))
 				end
 			else
-				sourceXPlayer.showNotification(_U('gave_weapon_hasalready', targetXPlayer.name, weaponLabel))
-				targetXPlayer.showNotification(_U('received_weapon_hasalready', sourceXPlayer.name, weaponLabel))
+				sourceXPlayer.showNotification(_U('imp_invalid_quantity'))
 			end
-		end
-	elseif type == 'item_ammo' then
-		if sourceXPlayer.hasWeapon(itemName) then
-			local weaponNum, weapon = sourceXPlayer.getWeapon(itemName)
+		elseif type == 'item_account' then
+			if itemCount > 0 and sourceXPlayer.getAccount(itemName).money >= itemCount then
+				sourceXPlayer.removeAccountMoney(itemName, itemCount)
+				targetXPlayer.addAccountMoney   (itemName, itemCount)
 
-			if targetXPlayer.hasWeapon(itemName) then
-				local _, weaponObject = ESX.GetWeapon(itemName)
+				sourceXPlayer.showNotification(_U('gave_account_money', ESX.Math.GroupDigits(itemCount), Config.Accounts[itemName], targetXPlayer.name))
+				targetXPlayer.showNotification(_U('received_account_money', ESX.Math.GroupDigits(itemCount), Config.Accounts[itemName], sourceXPlayer.name))
+			else
+				sourceXPlayer.showNotification(_U('imp_invalid_amount'))
+			end
+		elseif type == 'item_weapon' then
+			if sourceXPlayer.hasWeapon(itemName) then
+				local weaponLabel = ESX.GetWeaponLabel(itemName)
 
-				if weaponObject.ammo then
-					local ammoLabel = weaponObject.ammo.label
+				if not targetXPlayer.hasWeapon(itemName) then
+					local _, weapon = sourceXPlayer.getWeapon(itemName)
+					local _, weaponObject = ESX.GetWeapon(itemName)
+					itemCount = weapon.ammo
 
-					if weapon.ammo >= itemCount then
-						sourceXPlayer.removeWeaponAmmo(itemName, itemCount)
-						targetXPlayer.addWeaponAmmo(itemName, itemCount)
+					sourceXPlayer.removeWeapon(itemName)
+					targetXPlayer.addWeapon(itemName, itemCount)
 
-						sourceXPlayer.showNotification(_U('gave_weapon_ammo', itemCount, ammoLabel, weapon.label, targetXPlayer.name))
-						targetXPlayer.showNotification(_U('received_weapon_ammo', itemCount, ammoLabel, weapon.label, sourceXPlayer.name))
+					if weaponObject.ammo and itemCount > 0 then
+						local ammoLabel = weaponObject.ammo.label
+						sourceXPlayer.showNotification(_U('gave_weapon_withammo', weaponLabel, itemCount, ammoLabel, targetXPlayer.name))
+						targetXPlayer.showNotification(_U('received_weapon_withammo', weaponLabel, itemCount, ammoLabel, sourceXPlayer.name))
+					else
+						sourceXPlayer.showNotification(_U('gave_weapon', weaponLabel, targetXPlayer.name))
+						targetXPlayer.showNotification(_U('received_weapon', weaponLabel, sourceXPlayer.name))
 					end
+				else
+					sourceXPlayer.showNotification(_U('gave_weapon_hasalready', targetXPlayer.name, weaponLabel))
+					targetXPlayer.showNotification(_U('received_weapon_hasalready', sourceXPlayer.name, weaponLabel))
 				end
-			else
-				sourceXPlayer.showNotification(_U('gave_weapon_noweapon', targetXPlayer.name))
-				targetXPlayer.showNotification(_U('received_weapon_noweapon', sourceXPlayer.name, weapon.label))
+			end
+		elseif type == 'item_ammo' then
+			if sourceXPlayer.hasWeapon(itemName) then
+				local weaponNum, weapon = sourceXPlayer.getWeapon(itemName)
+
+				if targetXPlayer.hasWeapon(itemName) then
+					local _, weaponObject = ESX.GetWeapon(itemName)
+
+					if weaponObject.ammo then
+						local ammoLabel = weaponObject.ammo.label
+
+						if weapon.ammo >= itemCount then
+							sourceXPlayer.removeWeaponAmmo(itemName, itemCount)
+							targetXPlayer.addWeaponAmmo(itemName, itemCount)
+
+							sourceXPlayer.showNotification(_U('gave_weapon_ammo', itemCount, ammoLabel, weapon.label, targetXPlayer.name))
+							targetXPlayer.showNotification(_U('received_weapon_ammo', itemCount, ammoLabel, weapon.label, sourceXPlayer.name))
+						end
+					end
+				else
+					sourceXPlayer.showNotification(_U('gave_weapon_noweapon', targetXPlayer.name))
+					targetXPlayer.showNotification(_U('received_weapon_noweapon', sourceXPlayer.name, weapon.label))
+				end
 			end
 		end
-	end
-end)
+	end)
 
-RegisterNetEvent('esx:removeInventoryItem')
-AddEventHandler('esx:removeInventoryItem', function(type, itemName, itemCount)
-	local playerId = source
-	local xPlayer = ESX.GetPlayerFromId(source)
+	RegisterNetEvent('esx:removeInventoryItem')
+	AddEventHandler('esx:removeInventoryItem', function(type, itemName, itemCount)
+		local playerId = source
+		local xPlayer = ESX.GetPlayerFromId(source)
 
-	if type == 'item_standard' then
-		if itemCount == nil or itemCount < 1 then
-			xPlayer.showNotification(_U('imp_invalid_quantity'))
-		else
-			local xItem = xPlayer.getInventoryItem(itemName)
-
-			if (itemCount > xItem.count or xItem.count < 1) then
+		if type == 'item_standard' then
+			if itemCount == nil or itemCount < 1 then
 				xPlayer.showNotification(_U('imp_invalid_quantity'))
 			else
-				xPlayer.removeInventoryItem(itemName, itemCount)
-				local pickupLabel = ('~y~%s~s~ [~b~%s~s~]'):format(xItem.label, itemCount)
-				ESX.CreatePickup('item_standard', itemName, itemCount, pickupLabel, playerId)
-				xPlayer.showNotification(_U('threw_standard', itemCount, xItem.label))
-			end
-		end
-	elseif type == 'item_account' then
-		if itemCount == nil or itemCount < 1 then
-			xPlayer.showNotification(_U('imp_invalid_amount'))
-		else
-			local account = xPlayer.getAccount(itemName)
+				local xItem = xPlayer.getInventoryItem(itemName)
 
-			if (itemCount > account.money or account.money < 1) then
-				xPlayer.showNotification(_U('imp_invalid_amount'))
-			else
-				xPlayer.removeAccountMoney(itemName, itemCount)
-				local pickupLabel = ('~y~%s~s~ [~g~%s~s~]'):format(account.label, _U('locale_currency', ESX.Math.GroupDigits(itemCount)))
-				ESX.CreatePickup('item_account', itemName, itemCount, pickupLabel, playerId)
-				xPlayer.showNotification(_U('threw_account', ESX.Math.GroupDigits(itemCount), string.lower(account.label)))
-			end
-		end
-	elseif type == 'item_weapon' then
-		itemName = string.upper(itemName)
-
-		if xPlayer.hasWeapon(itemName) then
-			local _, weapon = xPlayer.getWeapon(itemName)
-			local _, weaponObject = ESX.GetWeapon(itemName)
-			local components, pickupLabel = ESX.Table.Clone(weapon.components)
-			xPlayer.removeWeapon(itemName)
-
-			if weaponObject.ammo and weapon.ammo > 0 then
-				local ammoLabel = weaponObject.ammo.label
-				pickupLabel = ('~y~%s~s~ [~g~%s~s~ %s]'):format(weapon.label, weapon.ammo, ammoLabel)
-				xPlayer.showNotification(_U('threw_weapon_ammo', weapon.label, weapon.ammo, ammoLabel))
-			else
-				pickupLabel = ('~y~%s~s~'):format(weapon.label)
-				xPlayer.showNotification(_U('threw_weapon', weapon.label))
-			end
-
-			ESX.CreatePickup('item_weapon', itemName, weapon.ammo, pickupLabel, playerId, components, weapon.tintIndex)
-		end
-	end
-end)
-
-RegisterNetEvent('esx:useItem')
-AddEventHandler('esx:useItem', function(itemName)
-	local xPlayer = ESX.GetPlayerFromId(source)
-	local count = xPlayer.getInventoryItem(itemName).count
-
-	if count > 0 then
-		ESX.UseItem(source, itemName)
-	else
-		xPlayer.showNotification(_U('act_imp'))
-	end
-end)
-
-RegisterNetEvent('esx:onPickup')
-AddEventHandler('esx:onPickup', function(pickupId)
-	local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)
-
-	if pickup then
-		if pickup.type == 'item_standard' then
-			if xPlayer.canCarryItem(pickup.name, pickup.count) then
-				xPlayer.addInventoryItem(pickup.name, pickup.count)
-				success = true
-			else
-				xPlayer.showNotification(_U('threw_cannot_pickup'))
-			end
-		elseif pickup.type == 'item_account' then
-			success = true
-			xPlayer.addAccountMoney(pickup.name, pickup.count)
-		elseif pickup.type == 'item_weapon' then
-			if xPlayer.hasWeapon(pickup.name) then
-				xPlayer.showNotification(_U('threw_weapon_already'))
-			else
-				success = true
-				xPlayer.addWeapon(pickup.name, pickup.count)
-				xPlayer.setWeaponTint(pickup.name, pickup.tintIndex)
-
-				for k,v in ipairs(pickup.components) do
-					xPlayer.addWeaponComponent(pickup.name, v)
+				if (itemCount > xItem.count or xItem.count < 1) then
+					xPlayer.showNotification(_U('imp_invalid_quantity'))
+				else
+					xPlayer.removeInventoryItem(itemName, itemCount)
+					local pickupLabel = ('~y~%s~s~ [~b~%s~s~]'):format(xItem.label, itemCount)
+					ESX.CreatePickup('item_standard', itemName, itemCount, pickupLabel, playerId)
+					xPlayer.showNotification(_U('threw_standard', itemCount, xItem.label))
 				end
 			end
-		end
+		elseif type == 'item_account' then
+			if itemCount == nil or itemCount < 1 then
+				xPlayer.showNotification(_U('imp_invalid_amount'))
+			else
+				local account = xPlayer.getAccount(itemName)
 
-		if success then
-			Core.Pickups[pickupId] = nil
-			TriggerClientEvent('esx:removePickup', -1, pickupId)
+				if (itemCount > account.money or account.money < 1) then
+					xPlayer.showNotification(_U('imp_invalid_amount'))
+				else
+					xPlayer.removeAccountMoney(itemName, itemCount)
+					local pickupLabel = ('~y~%s~s~ [~g~%s~s~]'):format(account.label, _U('locale_currency', ESX.Math.GroupDigits(itemCount)))
+					ESX.CreatePickup('item_account', itemName, itemCount, pickupLabel, playerId)
+					xPlayer.showNotification(_U('threw_account', ESX.Math.GroupDigits(itemCount), string.lower(account.label)))
+				end
+			end
+		elseif type == 'item_weapon' then
+			itemName = string.upper(itemName)
+
+			if xPlayer.hasWeapon(itemName) then
+				local _, weapon = xPlayer.getWeapon(itemName)
+				local _, weaponObject = ESX.GetWeapon(itemName)
+				local components, pickupLabel = ESX.Table.Clone(weapon.components)
+				xPlayer.removeWeapon(itemName)
+
+				if weaponObject.ammo and weapon.ammo > 0 then
+					local ammoLabel = weaponObject.ammo.label
+					pickupLabel = ('~y~%s~s~ [~g~%s~s~ %s]'):format(weapon.label, weapon.ammo, ammoLabel)
+					xPlayer.showNotification(_U('threw_weapon_ammo', weapon.label, weapon.ammo, ammoLabel))
+				else
+					pickupLabel = ('~y~%s~s~'):format(weapon.label)
+					xPlayer.showNotification(_U('threw_weapon', weapon.label))
+				end
+
+				ESX.CreatePickup('item_weapon', itemName, weapon.ammo, pickupLabel, playerId, components, weapon.tintIndex)
+			end
 		end
-	end
-end)
+	end)
+
+
+	RegisterNetEvent('esx:useItem')
+	AddEventHandler('esx:useItem', function(itemName)
+		local xPlayer = ESX.GetPlayerFromId(source)
+		local count = xPlayer.getInventoryItem(itemName).count
+
+		if count > 0 then
+			ESX.UseItem(source, itemName)
+		else
+			xPlayer.showNotification(_U('act_imp'))
+		end
+	end)
+
+	RegisterNetEvent('esx:onPickup')
+	AddEventHandler('esx:onPickup', function(pickupId)
+		local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)
+
+		if pickup then
+			if pickup.type == 'item_standard' then
+				if xPlayer.canCarryItem(pickup.name, pickup.count) then
+					xPlayer.addInventoryItem(pickup.name, pickup.count)
+					success = true
+				else
+					xPlayer.showNotification(_U('threw_cannot_pickup'))
+				end
+			elseif pickup.type == 'item_account' then
+				success = true
+				xPlayer.addAccountMoney(pickup.name, pickup.count)
+			elseif pickup.type == 'item_weapon' then
+				if xPlayer.hasWeapon(pickup.name) then
+					xPlayer.showNotification(_U('threw_weapon_already'))
+				else
+					success = true
+					xPlayer.addWeapon(pickup.name, pickup.count)
+					xPlayer.setWeaponTint(pickup.name, pickup.tintIndex)
+
+					for k,v in ipairs(pickup.components) do
+						xPlayer.addWeaponComponent(pickup.name, v)
+					end
+				end
+			end
+
+			if success then
+				Core.Pickups[pickupId] = nil
+				TriggerClientEvent('esx:removePickup', -1, pickupId)
+			end
+		end
+	end)
+end
 
 ESX.RegisterServerCallback('esx:getPlayerData', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)

--- a/[esx_addons]/esx_addoninventory/server/main.lua
+++ b/[esx_addons]/esx_addoninventory/server/main.lua
@@ -1,3 +1,19 @@
+if ESX.GetConfig().OxInventory then
+	AddEventHandler('onServerResourceStart', function(resourceName)
+		if resourceName == 'ox_inventory' or resourceName == GetCurrentResourceName() then
+			local stashes = MySQL.query.await('SELECT * FROM addon_inventory')
+
+			for i=1, #stashes do
+				local stash = stashes[i]
+				local jobStash = stash.name:find('society') and string.sub(stash.name, 9)
+				exports.ox_inventory:RegisterStash(stash.name, stash.label, 100, 200000, stash.shared == 0 and true or false, jobStash)
+			end
+		end
+	end)
+
+	return
+end
+
 Items = {}
 local InventoriesIndex, Inventories, SharedInventories = {}, {}, {}
 

--- a/[esx_addons]/esx_ambulancejob/config.lua
+++ b/[esx_addons]/esx_ambulancejob/config.lua
@@ -23,6 +23,8 @@ Config.RemoveItemsAfterRPDeath    = true
 Config.EarlyRespawnFine           = false
 Config.EarlyRespawnFineAmount     = 5000
 
+Config.OxInventory                = ESX.GetConfig().OxInventory
+
 Config.RespawnPoint = {coords = vector3(341.0, -1397.3, 32.5), heading = 48.5}
 
 Config.Hospitals = {

--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -100,6 +100,10 @@ end)
 ESX.RegisterServerCallback('esx_ambulancejob:removeItemsAfterRPDeath', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)
 
+	if Config.OxInventory and Config.RemoveItemsAfterRPDeath then
+		return exports.ox_inventory:ClearInventory(xPlayer.source)
+	end
+
 	if Config.RemoveCashAfterRPDeath then
 		if xPlayer.getMoney() > 0 then
 			xPlayer.removeMoney(xPlayer.getMoney())
@@ -117,6 +121,8 @@ ESX.RegisterServerCallback('esx_ambulancejob:removeItemsAfterRPDeath', function(
 			end
 		end
 	end
+
+	if Config.OxInventory then return end
 
 	local playerLoadout = {}
 	if Config.RemoveWeaponsAfterRPDeath then

--- a/[esx_addons]/esx_mechanicjob/client/main.lua
+++ b/[esx_addons]/esx_mechanicjob/client/main.lua
@@ -162,6 +162,10 @@ function OpenMechanicActionsMenu()
 			ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin, jobSkin)
 				TriggerEvent('skinchanger:loadSkin', skin)
 			end)
+
+		elseif Config.OxInventory and (data.current.value == 'put_stock' or data.current.value == 'get_stock') then
+			exports.ox_inventory:openInventory('stash', 'society_mechanic')
+			return ESX.UI.Menu.CloseAll()
 		elseif data.current.value == 'put_stock' then
 			OpenPutStocksMenu()
 		elseif data.current.value == 'get_stock' then

--- a/[esx_addons]/esx_mechanicjob/config.lua
+++ b/[esx_addons]/esx_mechanicjob/config.lua
@@ -10,6 +10,8 @@ Config.NPCSpawnDistance           = 500.0
 Config.NPCNextToDistance          = 25.0
 Config.NPCJobEarnings             = { min = 15, max = 40 }
 
+Config.OxInventory                = ESX.GetConfig().OxInventory
+
 Config.Vehicles = {
 	'adder',
 	'asea',

--- a/[esx_addons]/esx_policejob/client/main.lua
+++ b/[esx_addons]/esx_policejob/client/main.lua
@@ -204,15 +204,21 @@ function OpenCloakroomMenu()
 end
 
 function OpenArmoryMenu(station)
-	local elements = {
-		{label = _U('buy_weapons'), value = 'buy_weapons'}
-	}
+	local elements
+	if Config.OxInventory then
+		exports.ox_inventory:openInventory('stash', {id = 'society_police', owner = station})
+		return ESX.UI.Menu.CloseAll()
+	else
+		elements = {
+			{label = _U('buy_weapons'), value = 'buy_weapons'}
+		}
 
-	if Config.EnableArmoryManagement then
-		table.insert(elements, {label = _U('get_weapon'),     value = 'get_weapon'})
-		table.insert(elements, {label = _U('put_weapon'),     value = 'put_weapon'})
-		table.insert(elements, {label = _U('remove_object'),  value = 'get_stock'})
-		table.insert(elements, {label = _U('deposit_object'), value = 'put_stock'})
+		if Config.EnableArmoryManagement then
+			table.insert(elements, {label = _U('get_weapon'),     value = 'get_weapon'})
+			table.insert(elements, {label = _U('put_weapon'),     value = 'put_weapon'})
+			table.insert(elements, {label = _U('remove_object'),  value = 'get_stock'})
+			table.insert(elements, {label = _U('deposit_object'), value = 'put_stock'})
+		end
 	end
 
 	ESX.UI.Menu.CloseAll()
@@ -446,6 +452,11 @@ function OpenIdentityCardMenu(player)
 end
 
 function OpenBodySearchMenu(player)
+	if Config.OxInventory then
+		exports.ox_inventory:openInventory('player', GetPlayerServerId(closestPlayer))
+		return ESX.UI.Menu.CloseAll()
+	end
+
 	ESX.TriggerServerCallback('esx_policejob:getOtherPlayerData', function(data)
 		local elements = {}
 

--- a/[esx_addons]/esx_policejob/config.lua
+++ b/[esx_addons]/esx_policejob/config.lua
@@ -22,6 +22,8 @@ Config.MaxInService               = -1 -- How many people can be in service at o
 
 Config.Locale                     = 'en'
 
+Config.OxInventory                = ESX.GetConfig().OxInventory
+
 Config.PoliceStations = {
 
 	LSPD = {

--- a/[esx_addons]/esx_property/client/main.lua
+++ b/[esx_addons]/esx_property/client/main.lua
@@ -400,8 +400,12 @@ function OpenRoomMenu(property, owner)
 		table.insert(elements, {label = _U('remove_cloth'), value = 'remove_cloth'})
 	end
 
-	table.insert(elements, {label = _U('remove_object'),  value = 'room_inventory'})
-	table.insert(elements, {label = _U('deposit_object'), value = 'player_inventory'})
+	if Config.OxInventory then
+		table.insert(elements, {label = _U('remove_object'),  value = 'room_inventory'})
+	else
+		table.insert(elements, {label = _U('remove_object'),  value = 'room_inventory'})
+		table.insert(elements, {label = _U('deposit_object'), value = 'player_inventory'})
+	end
 
 	ESX.UI.Menu.CloseAll()
 
@@ -506,6 +510,11 @@ function OpenRoomMenu(property, owner)
 end
 
 function OpenRoomInventoryMenu(property, owner)
+	if Config.OxInventory then
+		exports.ox_inventory:openInventory('stash', {id = property.name, owner = owner})
+		return ESX.UI.Menu.CloseAll()
+	end
+
 	ESX.TriggerServerCallback('esx_property:getPropertyInventory', function(inventory)
 		local elements = {}
 

--- a/[esx_addons]/esx_property/config.lua
+++ b/[esx_addons]/esx_property/config.lua
@@ -14,3 +14,5 @@ Config.Properties = {}
 
 Config.EnablePlayerManagement = false -- If set to true you use esx_realestateagentjob
 Config.Locale = 'en'
+
+Config.OxInventory = ESX.GetConfig().OxInventory

--- a/[esx_addons]/esx_property/server/main.lua
+++ b/[esx_addons]/esx_property/server/main.lua
@@ -52,6 +52,12 @@ function RemoveOwnedProperty(name, owner, noPay)
 						end
 					end
 				end
+
+				if Config.OxInventory then
+					MySQL.query('DELETE FROM ox_inventory WHERE owner = ? AND name = ?', {
+						owner, ('%s%s'):format(owner, name)
+					})
+				end
 			end)
 		end
 	end)
@@ -63,6 +69,7 @@ MySQL.ready(function()
 	MySQL.query('SELECT * FROM `properties`', {}, function(properties)
 
 		for i=1, #properties, 1 do
+			local property = properties[i]
 			local entering  = nil
 			local exit      = nil
 			local inside    = nil
@@ -72,59 +79,63 @@ MySQL.ready(function()
 			local isGateway = nil
 			local roomMenu  = nil
 
-			if properties[i].entering then
-				entering = json.decode(properties[i].entering)
+			if property.entering then
+				entering = json.decode(property.entering)
 			end
 
-			if properties[i].exit then
-				exit = json.decode(properties[i].exit)
+			if property.exit then
+				exit = json.decode(property.exit)
 			end
 
-			if properties[i].inside then
-				inside = json.decode(properties[i].inside)
+			if property.inside then
+				inside = json.decode(property.inside)
 			end
 
-			if properties[i].outside then
-				outside = json.decode(properties[i].outside)
+			if property.outside then
+				outside = json.decode(property.outside)
 			end
 
-			if properties[i].is_single == 0 then
+			if property.is_single == 0 then
 				isSingle = false
 			else
 				isSingle = true
 			end
 
-			if properties[i].is_room == 0 then
+			if property.is_room == 0 then
 				isRoom = false
 			else
 				isRoom = true
 			end
 
-			if properties[i].is_gateway == 0 then
+			if property.is_gateway == 0 then
 				isGateway = false
 			else
 				isGateway = true
 			end
 
-			if properties[i].room_menu then
-				roomMenu = json.decode(properties[i].room_menu)
+			if property.room_menu then
+				roomMenu = json.decode(property.room_menu)
 			end
 
 			table.insert(Config.Properties, {
-				name      = properties[i].name,
-				label     = properties[i].label,
+				name      = property.name,
+				label     = property.label,
 				entering  = entering,
 				exit      = exit,
 				inside    = inside,
 				outside   = outside,
-				ipls      = json.decode(properties[i].ipls),
-				gateway   = properties[i].gateway,
+				ipls      = json.decode(property.ipls),
+				gateway   = property.gateway,
 				isSingle  = isSingle,
 				isRoom    = isRoom,
 				isGateway = isGateway,
 				roomMenu  = roomMenu,
-				price     = properties[i].price
+				price     = property.price
 			})
+
+			if Config.OxInventory then
+				exports.ox_inventory:RegisterStash(property.name, property.label, 50, 100000, true)
+			end
 		end
 
 		TriggerClientEvent('esx_property:sendProperties', -1, Config.Properties)

--- a/[esx_addons]/esx_taxijob/client/main.lua
+++ b/[esx_addons]/esx_taxijob/client/main.lua
@@ -232,7 +232,10 @@ function OpenTaxiActionsMenu()
 		elements = elements
 	}, function(data, menu)
 
-		if data.current.value == 'put_stock' then
+		if Config.OxInventory and (data.current.value == 'put_stock' or data.current.value == 'get_stock') then
+			exports.ox_inventory:openInventory('stash', 'society_taxi')
+			return ESX.UI.Menu.CloseAll()
+		elseif data.current.value == 'put_stock' then
 			OpenPutStocksMenu()
 		elseif data.current.value == 'get_stock' then
 			OpenGetStocksMenu()

--- a/[esx_addons]/esx_taxijob/config.lua
+++ b/[esx_addons]/esx_taxijob/config.lua
@@ -11,6 +11,8 @@ Config.EnableSocietyOwnedVehicles = false
 
 Config.Locale                     = 'en'
 
+Config.OxInventory                = ESX.GetConfig().OxInventory
+
 Config.AuthorizedVehicles = {
 	{model = 'taxi', label = 'Taxi'}
 }

--- a/[esx_addons]/esx_vehicleshop/client/main.lua
+++ b/[esx_addons]/esx_vehicleshop/client/main.lua
@@ -326,7 +326,9 @@ function OpenResellerMenu()
 	}}, function(data, menu)
 		local action = data.current.value
 
-		if action == 'buy_vehicle' then
+		if Config.OxInventory and (action == 'put_stock' or action == 'get_stock') then
+			exports.ox_inventory:openInventory('stash', 'society_cardealer')
+		elseif action == 'buy_vehicle' then
 			OpenShopMenu()
 		elseif action == 'put_stock' then
 			OpenPutStocksMenu()

--- a/[esx_addons]/esx_vehicleshop/config.lua
+++ b/[esx_addons]/esx_vehicleshop/config.lua
@@ -14,6 +14,8 @@ Config.PlateLetters  = 3
 Config.PlateNumbers  = 3
 Config.PlateUseSpace = true
 
+Config.OxInventory = ESX.GetConfig().OxInventory
+
 Config.Zones = {
 
 	ShopEntering = {

--- a/[esx_addons]/esx_weaponshop/config.lua
+++ b/[esx_addons]/esx_weaponshop/config.lua
@@ -7,6 +7,8 @@ Config.Type          = 1
 
 Config.Locale        = 'en'
 
+Config.OxInventory   = ESX.GetConfig().OxInventory
+
 Config.LicenseEnable = false -- only turn this on if you are using esx_license
 Config.LicensePrice  = 5000
 


### PR DESCRIPTION
Fairly low effort to get the the basics working.
- Register addon inventories as stashes
- Open inventory with job stashes and search player
- Disable a bunch of standard code or call inventory exports instead

Checks if the resource exists and sets `Config.OxInventory` inside ESX. Other resources just need a simple
```lua
Config.OxInventory = ESX.GetConfig().OxInventory
```

I don't really want to do any more than this.