### PR TITLE
Fix Bug: Cannot pickup weed plant

### DIFF
--- a/[esx_addons]/esx_drugs/client/weed.lua
+++ b/[esx_addons]/esx_drugs/client/weed.lua
@@ -80,7 +80,7 @@ CreateThread(function()
 		local nearbyObject, nearbyID
 
 		for i=1, #weedPlants, 1 do
-			if #(coords - GetEntityCoords(weedPlants[i])) < 1 then
+			if #(coords - GetEntityCoords(weedPlants[i])) < 1.5 then
 				nearbyObject, nearbyID = weedPlants[i], i
 			end
 		end


### PR DESCRIPTION
cannot pickup weed plant 
because distance from player coords and weedplant object 
the distance is too small 
should be 1.5 not 1.0