### PR TITLE
Fix Error: esx_garage when player enter to zone

### DIFF
--- a/[esx_addons]/esx_garage/client/main.lua
+++ b/[esx_addons]/esx_garage/client/main.lua
@@ -1,6 +1,8 @@
 local LastGarage, LastPart, LastParking, thisGarage = nil, nil, nil, nil
 
-TriggerEvent('instance:registerType', 'garage')
+AddEventHandler('instance:loaded', function()
+	TriggerEvent('instance:registerType', 'garage')
+end)
 
 RegisterNetEvent('instance:onCreate')
 AddEventHandler('instance:onCreate', function(instance)


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/817059034699399259/944153115534458880/unknown.png
because registerType instance garage it call a function when "script instance" running setup script.
we should wait script "instance" loaded or setup successfully 
and we will be able to execute the "register instance type" function