### PR TITLE
feat: extend GetIdentifier function

### DIFF
--- a/[esx]/es_extended/server/functions.lua
+++ b/[esx]/es_extended/server/functions.lua
@@ -245,13 +245,14 @@ function ESX.GetPlayerFromIdentifier(identifier)
 	end
 end
 
-function ESX.GetIdentifier(playerId)
-	for k,v in ipairs(GetPlayerIdentifiers(playerId)) do
-		if string.match(v, 'license:') then
-			local identifier = string.gsub(v, 'license:', '')
-			return identifier
+function ESX.GetIdentifier(playerId, _identifierType)
+	local identifierType = _identifierType..':' or 'license:'
+	for _, v in pairs(GetPlayerIdentifiers(playerId)) do
+		if string.match(v, identifierType) then
+			return string.gsub(v, identifierType, '')
 		end
 	end
+	return false
 end
 
 function ESX.RegisterUsableItem(item, cb)


### PR DESCRIPTION
This may be useful for anyone who wants to get an identifier which is not license. (eg. whitelists are usually done through steam identifiers)