### PR TITLE
fix(esx/player): improve accounts sync with ox inventory

### DIFF
--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -196,13 +196,12 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 			local account = self.getAccount(accountName)
 
 			if account then
-				local prevMoney = account.money
 				local newMoney = ESX.Math.Round(money)
 				account.money = newMoney
 
 				self.triggerEvent('esx:setAccountMoney', account)
 
-				if Inventory and (accountName == 'money' or accountName == 'black_money') then
+				if Inventory and Inventory.accounts[accountName] then
 					Inventory.SetItem(self.source, accountName, money)
 				end
 			end
@@ -219,7 +218,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 				self.triggerEvent('esx:setAccountMoney', account)
 
-				if Inventory and (accountName == 'money' or accountName == 'black_money') then
+				if Inventory and Inventory.accounts[accountName] then
 					Inventory.AddItem(self.source, accountName, money)
 				end
 			end
@@ -236,7 +235,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 				self.triggerEvent('esx:setAccountMoney', account)
 
-				if Inventory and (accountName == 'money' or accountName == 'black_money') then
+				if Inventory and Inventory.accounts[accountName] then
 					Inventory.RemoveItem(self.source, accountName, money)
 				end
 			end


### PR DESCRIPTION
Having to update accounts with physical items to sync in multiple places just makes for a bad time.