### PR TITLE
Increase sender length to 60

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -91,7 +91,7 @@ CREATE TABLE `addon_inventory_items` (
 CREATE TABLE `billing` (
   `id` int(11) NOT NULL,
   `identifier` varchar(60) NOT NULL,
-  `sender` varchar(40) NOT NULL,
+  `sender` varchar(60) NOT NULL,
   `target_type` varchar(50) NOT NULL,
   `target` varchar(40) NOT NULL,
   `label` varchar(255) NOT NULL,


### PR DESCRIPTION
If the players are saved with a rockstar license, forty is very little, so when giving invoices, there is an error in the notifications.