### PR TITLE
add bt-target support for esx_sit

### DIFF
--- a/[esx_addons]/esx_sit/client.lua
+++ b/[esx_addons]/esx_sit/client.lua
@@ -145,3 +145,24 @@ function sit(object, modelName, data)
 		end
 	end, objectCoords)
 end
+
+Citizen.CreateThread(function()
+	local Sitables = {}
+
+	for k,v in pairs(Config.Interactables) do
+		local model = GetHashKey(v)
+		table.insert(Sitables, model)
+	end
+	Wait(100)
+	exports['bt-target']:AddTargetModel(Sitables, {
+        options = {
+            {
+                event = "sit:sit",
+                icon = "fas fa-chair",
+                label = "Sit down in a chair",
+            },
+        },
+        job = {"all"},
+        distance = Config.MaxDistance
+    })
+end)


### PR DESCRIPTION
If those who prefer to use bt-target instead of using a command to sit-down in a chair, this will offer that support.