### PR TITLE
Add shops table

### DIFF
--- a/[esx_addons]/esx_optionalneeds/esx_optionalneeds.sql
+++ b/[esx_addons]/esx_optionalneeds/esx_optionalneeds.sql
@@ -1,5 +1,14 @@
 USE `es_extended`;
 
+CREATE TABLE `shops` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`store` varchar(100) NOT NULL,
+	`item` varchar(100) NOT NULL,
+	`price` int(11) NOT NULL,
+
+	PRIMARY KEY (`id`)
+);
+
 INSERT INTO `items` (`name`, `label`, `weight`) VALUES
 	('beer', 'Beer', 1)
 ;


### PR DESCRIPTION
The table `shops` doesn't exist in any other module. I've created [a pull request to add it in esx_shops](https://github.com/esx-framework/esx-legacy/pull/206) but it has been rejected. So, even if it doesn't make sense for me, let add it in the module that uses it.