### PR TITLE
refactor(esx_jobs): Correct start order for functioning

### DIFF
--- a/[esx_addons]/esx_jobs/fxmanifest.lua
+++ b/[esx_addons]/esx_jobs/fxmanifest.lua
@@ -9,9 +9,9 @@ version '1.6.5'
 shared_scripts {
 	'@es_extended/imports.lua',
 	'@es_extended/locale.lua',
-	'config.lua',
-	'jobs/*.lua',
 	'locales/*.lua',
+	'config.lua',
+	'jobs/*.lua'
 }
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',

--- a/[esx_addons]/esx_jobs/fxmanifest.lua
+++ b/[esx_addons]/esx_jobs/fxmanifest.lua
@@ -10,17 +10,16 @@ shared_scripts {
 	'@es_extended/imports.lua',
 	'@es_extended/locale.lua',
 	'locales/*.lua',
-	'config.lua'
+	'config.lua',
+	'jobs/*.lua'
 }
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',
 	'server/main.lua'
-	'jobs/*.lua'
 }
 
 client_scripts {
-	'client/main.lua',
-	'jobs/*.lua'
+	'client/main.lua'
 }
 
 dependency 'es_extended'

--- a/[esx_addons]/esx_jobs/fxmanifest.lua
+++ b/[esx_addons]/esx_jobs/fxmanifest.lua
@@ -10,16 +10,17 @@ shared_scripts {
 	'@es_extended/imports.lua',
 	'@es_extended/locale.lua',
 	'locales/*.lua',
-	'config.lua',
-	'jobs/*.lua'
+	'config.lua'
 }
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',
 	'server/main.lua'
+	'jobs/*.lua'
 }
 
 client_scripts {
-	'client/main.lua'
+	'client/main.lua',
+	'jobs/*.lua'
 }
 
 dependency 'es_extended'


### PR DESCRIPTION
Fix for this: 
![image](https://user-images.githubusercontent.com/29688478/163424520-d3d67e1e-c498-4ead-b3ff-8a918d2c8f9a.png)

After doing that ^, thought about other errors and here we go, ~~we can't start job lua's before we load `client` and `server` lua's~~. Actually `main.lua:28` uses locales, so we can load them from shared_scripts apparently.
> [script:esx_jobs] SCRIPT ERROR: @esx_jobs/server/main.lua:28: attempt to index a nil value
fix #210 

