### PR TITLE
fix: Fix everytime player join server found dead if he was alive at time of leaving server

### DIFF
--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -296,6 +296,7 @@ end)
 ESX.RegisterServerCallback('esx_ambulancejob:getDeathStatus', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(source)
 	MySQL.scalar('SELECT is_dead FROM users WHERE identifier = ?', {xPlayer.identifier}, function(isDead)
+	local isDead = isDead == 1 and true or false
 		cb(isDead)
 	end)
 end)


### PR DESCRIPTION
before somehow dev remove the check so i just put back the check to get status if player is dead according to saved values in database then on player join it will not kill player but if player is dead according to database it will kill player on server join 
its a bug in this release so i fix it back and copy this code from old files of legacy not my own written.