### PR TITLE
feat(esx_society | config & client) Added societies defaultOptions to config.lua

### DIFF
--- a/[esx_addons]/esx_society/client/main.lua
+++ b/[esx_addons]/esx_society/client/main.lua
@@ -69,11 +69,11 @@ function OpenBossMenu(society, close, options)
 	ESX.TriggerServerCallback('esx_society:isBoss', function(isBoss)
 		if isBoss then
 			local defaultOptions = {
-				withdraw = true,
-				deposit = true,
-				wash = true,
-				employees = true,
-				grades = true
+				withdraw = Config.Withdraw,
+				deposit = Config.Deposit,
+				wash = Config.Wash,
+				employees = Config.EmployeesManagement,
+				grades = Config.GradesManagement
 			}
 
 			for k,v in pairs(defaultOptions) do

--- a/[esx_addons]/esx_society/config.lua
+++ b/[esx_addons]/esx_society/config.lua
@@ -3,3 +3,10 @@ Config = {}
 Config.Locale = 'en'
 Config.EnableESXIdentity = true
 Config.MaxSalary = 3500
+
+
+Config.Withdraw = true
+Config.Deposit  = true
+Config.Wash     = false
+Config.EmployeesManagement = true
+Config.GradesManagement = false


### PR DESCRIPTION
The options withdraw, deposit, wash, employees and grades now are configurable on the Config.lua instead of in the client main.lua.