### PR TITLE
fix(locales) esx_ambulancejob translation file

### DIFF
--- a/[esx_addons]/esx_ambulancejob/locales/br.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/br.lua
@@ -64,12 +64,12 @@ Locales['br'] = {
   -- Phone
   ['alert_ambulance'] = 'alerta socorrista',
   -- Death
-  ['respawn_available_in'] = 'você irar reviver em  %s minutos %s segundos',
-  ['respawn_bleedout_in'] = 'você vai sangrar  %s minutos %s segundos\n',
-  ['respawn_bleedout_prompt'] = 'aguarde [ E] para reviver',
-  ['respawn_bleedout_fine'] = 'aguarde [ E] para reviver por $%s',
-  ['respawn_bleedout_fine_msg'] = 'você precisa pagar   para reviver',
-  ['distress_send'] = 'pressione [~bs~] enviar sinal de socorro',
+  ['respawn_available_in'] = 'você irar reviver em %s minutos %s segundos',
+  ['respawn_bleedout_in'] = 'você vai sangrar %s minutos %s segundos\n',
+  ['respawn_bleedout_prompt'] = 'aguarde [E] para reviver',
+  ['respawn_bleedout_fine'] = 'aguarde [E] para reviver por $%s',
+  ['respawn_bleedout_fine_msg'] = 'você precisa pagar $%s para reviver',
+  ['distress_send'] = 'pressione [G] enviar sinal de socorro',
   ['distress_sent'] = 'sinal de socorro foi enviado para as unidades disponíveis!',
 
   -- Revive
@@ -77,8 +77,8 @@ Locales['br'] = {
   -- Item
   ['used_medikit'] = 'você usou 1x Seringa',
   ['used_bandage'] = 'você usou 1x Vendagem',
-  ['not_enough_medikit'] = 'você não tem  Seringa.',
-  ['not_enough_bandage'] = 'você não tem  Vendagem.',
+  ['not_enough_medikit'] = 'você não tem seringa.',
+  ['not_enough_bandage'] = 'você não tem vendagem.',
   ['healed'] = 'você foi tratado.',
   -- Blips
   ['blip_hospital'] = 'hospital',

--- a/[esx_addons]/esx_ambulancejob/locales/cs.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/cs.lua
@@ -64,19 +64,19 @@ Locales['cs'] = {
   -- Phone
   ['alert_ambulance'] = 'zdravotnický poplach',
   -- Death
-  ['respawn_available_in'] = 'oživení dostupné za  %s minut a %s sekund\n',
-  ['respawn_bleedout_in'] = 'vykrvácíte za  %s minut a %s sekund\n',
-  ['respawn_bleedout_prompt'] = 'držte [ E] pro respawn.',
-  ['respawn_now_fine'] = 'držte [ E] pro oživení za $%s',
-  ['respawn_bleedout_fine_msg'] = 'zaplatili jste   za respawn.',
-  ['distress_send'] = 'stiskněte [~bs~] pro vyslání tísňového signálu',
+  ['respawn_available_in'] = 'oživení dostupné za %s minut a %s sekund\n',
+  ['respawn_bleedout_in'] = 'vykrvácíte za %s minut a %s sekund\n',
+  ['respawn_bleedout_prompt'] = 'držte [E] pro respawn.',
+  ['respawn_now_fine'] = 'držte [E] pro oživení za $%s',
+  ['respawn_bleedout_fine_msg'] = 'zaplatili jste $%s za respawn.',
+  ['distress_send'] = 'stiskněte [G] pro vyslání tísňového signálu',
   ['distress_sent'] = 'tísňový signál byl vyslán dostupným jednotkám!',
   -- Revive
   ['revive_help'] = 'oživit hráče',
   -- Item
   ['used_medikit'] = 'použili jste 1x lékarničku',
   ['used_bandage'] = 'použili jste 1x obvaz',
-  ['not_enough_medikit'] = 'nemáte  medikit.',
+  ['not_enough_medikit'] = 'nemáte medikit.',
   ['not_enough_bandage'] = 'nemáte bandage.',
   ['healed'] = 'byli jste ošetřeni.',
   -- Blips

--- a/[esx_addons]/esx_ambulancejob/locales/de.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/de.lua
@@ -63,20 +63,20 @@ Locales['de'] = {
   -- Phone
   ['alert_ambulance'] = 'Rettungsdienst alarmieren',
   -- Death
-  ['respawn_available_in'] = 'Respawn in  %s Minuten %s Sekundenrfügbar',
-  ['respawn_bleedout_in'] = 'Du wirst in  %s Minuten %s Sekundensbluten\n',
-  ['respawn_bleedout_prompt'] = 'Drücke [ Em zu respawnen',
-  ['respawn_bleedout_fine'] = 'Drücke [ Em für $%s zuspawnen',
-  ['respawn_bleedout_fine_msg'] = 'Du hast   bezahlt, um zu respawnen.',
-  ['distress_send'] = 'Drücke [~bs~] um ein Notsignal zu senden',
+  ['respawn_available_in'] = 'Respawn in %s Minuten %s Sekundenrfügbar',
+  ['respawn_bleedout_in'] = 'Du wirst in %s Minuten %s Sekundensbluten\n',
+  ['respawn_bleedout_prompt'] = 'Drücke [E] zu respawnen',
+  ['respawn_bleedout_fine'] = 'Drücke [E] für $%s zuspawnen',
+  ['respawn_bleedout_fine_msg'] = 'Du hast $%s bezahlt, um zu respawnen.',
+  ['distress_send'] = 'Drücke [G] um ein Notsignal zu senden',
   ['distress_sent'] = 'Notsignal wurde an den Rettungsdienst übermittelt!',
   -- Revive
   ['revive_help'] = 'Belebe einen Spieler wieder',
   -- Item
   ['used_medikit'] = 'Du hast eindikit verwendet',
   ['used_bandage'] = 'Du hast einenrband verwendet',
-  ['not_enough_medikit'] = 'Du hast keine Medikits',
-  ['not_enough_bandage'] = 'Du hast keine Verbände',
+  ['not_enough_medikit'] = 'Du hast keine medikits',
+  ['not_enough_bandage'] = 'Du hast keine verbände',
   ['healed'] = 'Du wurdest behandelt.',
   -- Blips
   ['blip_hospital'] = 'Krankenhaus',

--- a/[esx_addons]/esx_ambulancejob/locales/en.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/en.lua
@@ -76,8 +76,8 @@ Locales['en'] = {
   -- Item
   ['used_medikit'] = 'You have used 1x medikit',
   ['used_bandage'] = 'You have used 1x bandage',
-  ['not_enough_medikit'] = 'You do not have  medikit.',
-  ['not_enough_bandage'] = 'You do not have  bandage.',
+  ['not_enough_medikit'] = 'You do not have medikit.',
+  ['not_enough_bandage'] = 'You do not have bandage.',
   ['healed'] = 'You have been treated.',
   -- Blips
   ['blip_hospital'] = 'Hospital',

--- a/[esx_addons]/esx_ambulancejob/locales/es.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/es.lua
@@ -44,7 +44,7 @@ Locales['es'] = {
   -- Boss Menu
   ['boss_actions'] = 'Acciones del jefe',
   -- Misc
-  ['invalid_amount'] = ' ad no válida',
+  ['invalid_amount'] = 'Cantidad no válida',
   ['actions_prompt'] = 'Presiona [E] acceder al Acciones de ambulancia.',
   ['deposit_amount'] = 'Cantidad de fianza depositada',
   ['money_withdraw'] = 'Cantidad de fianza retirada',
@@ -66,7 +66,7 @@ Locales['es'] = {
   -- Phone
   ['alert_ambulance'] = 'Alerta de ambulancia',
   -- Death
-  ['respawn_available_in'] = 'Reaparición disponible en  %s minutes %s seconds',
+  ['respawn_available_in'] = 'Reaparición disponible en %s minutes %s seconds',
   ['respawn_bleedout_in'] = 'te desangrarás en %s minutes %s seconds\n',
   ['respawn_bleedout_prompt'] = 'Mantén [E] reaparecer',
   ['respawn_bleedout_fine'] = 'Mantén [E] para reaparecer $%s',
@@ -79,8 +79,8 @@ Locales['es'] = {
   -- Item
   ['used_medikit'] = 'Has usado 1x Kit médico',
   ['used_bandage'] = 'Has usado 1x Vendas',
-  ['not_enough_medikit'] = 'Usted no tiene Kit médico.',
-  ['not_enough_bandage'] = 'Usted no tiene Vendas.',
+  ['not_enough_medikit'] = 'Usted no tiene kit médico.',
+  ['not_enough_bandage'] = 'Usted no tiene vendas.',
   ['healed'] = 'Has sido tratado.',
   -- Blips
   ['blip_hospital'] = 'Hospital',

--- a/[esx_addons]/esx_ambulancejob/locales/fi.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/fi.lua
@@ -64,20 +64,20 @@ Locales['fi'] = {
   -- Phone
   ['alert_ambulance'] = 'hälyytys Ensihoidolle',
   -- Death
-  ['respawn_available_in'] = 'respawn available in  %s minutes %s seconds',
-  ['respawn_bleedout_in'] = 'you will bleed out in  %s minutes %s seconds\n',
-  ['respawn_bleedout_prompt'] = 'hold [ E] to respawn',
-  ['respawn_bleedout_fine'] = 'hold [ E] to respawn for $%s',
-  ['respawn_bleedout_fine_msg'] = 'you paid   to respawn.',
-  ['distress_send'] = 'press [~bs~] to send distress signal',
+  ['respawn_available_in'] = 'respawn available in %s minutes %s seconds',
+  ['respawn_bleedout_in'] = 'you will bleed out in %s minutes %s seconds\n',
+  ['respawn_bleedout_prompt'] = 'hold [E] to respawn',
+  ['respawn_bleedout_fine'] = 'hold [E] to respawn for $%s',
+  ['respawn_bleedout_fine_msg'] = 'you paid $%s to respawn.',
+  ['distress_send'] = 'press [G] to send distress signal',
   ['distress_sent'] = 'distress signal has been sent to available units!',
   -- Revive
   ['revive_help'] = 'elvytä pelaaja',
   -- Item
   ['used_medikit'] = 'sinä käytit ensiapupakkauksen',
   ['used_bandage'] = 'sinä käytit sideharsoja',
-  ['not_enough_medikit'] = 'ei tarpeeksi  ensiapupakkauksia.',
-  ['not_enough_bandage'] = 'ei tarpeeksi  sideharsoja.',
+  ['not_enough_medikit'] = 'ei tarpeeksi ensiapupakkauksia.',
+  ['not_enough_bandage'] = 'ei tarpeeksi sideharsoja.',
   ['healed'] = 'sinua parannettiin',
   -- Blips
   ['blip_hospital'] = 'sairaala',

--- a/[esx_addons]/esx_ambulancejob/locales/fr.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/fr.lua
@@ -64,20 +64,20 @@ Locales['fr'] = {
   -- Phone
   ['alert_ambulance'] = 'alerte Ambulance',
   -- Death
-  ['respawn_available_in'] = 'réanimation possible dans  %s minutes %s secondes',
-  ['respawn_bleedout_in'] = 'vous allez souffrir d\'une hémorragie dans  %s minutes %s secondes\n',
-  ['respawn_bleedout_prompt'] = 'maintenez [ E] pour être réanimé',
-  ['respawn_bleedout_fine'] = 'maintenez [ E] pour être réanimé pour $%s',
-  ['respawn_bleedout_fine_msg'] = 'vous avez payé   pour être réanimer.',
-  ['distress_send'] = 'appuyez sur [~bs~] pour envoyer un signal de détresse',
+  ['respawn_available_in'] = 'réanimation possible dans %s minutes %s secondes',
+  ['respawn_bleedout_in'] = 'vous allez souffrir d\'une hémorragie dans %s minutes %s secondes\n',
+  ['respawn_bleedout_prompt'] = 'maintenez [E] pour être réanimé',
+  ['respawn_bleedout_fine'] = 'maintenez [E] pour être réanimé pour $%s',
+  ['respawn_bleedout_fine_msg'] = 'vous avez payé $%s pour être réanimer.',
+  ['distress_send'] = 'appuyez sur [G] pour envoyer un signal de détresse',
   ['distress_sent'] = 'un signal a été envoyé à toutes les unités disponibles!',
   -- Revive
   ['revive_help'] = 'relancer un joueur',
   -- Item
   ['used_medikit'] = 'vous avez utilisé 1x kit de soin',
   ['used_bandage'] = 'vous avez utilisé 1x bandage',
-  ['not_enough_medikit'] = 'vous n\'avez pas de  kit de soin.',
-  ['not_enough_bandage'] = 'vous n\'avez pas de  bandage.',
+  ['not_enough_medikit'] = 'vous n\'avez pas de kit de soin.',
+  ['not_enough_bandage'] = 'vous n\'avez pas de bandage.',
   ['healed'] = 'vous avez été soigné.',
   -- Blips
   ['blip_hospital'] = 'hôpital',

--- a/[esx_addons]/esx_ambulancejob/locales/hu.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/hu.lua
@@ -64,20 +64,20 @@ Locales['hu'] = {
   -- Phone
   ['alert_ambulance'] = 'EMS értesités',
   -- Death
-  ['respawn_available_in'] = 'Újraéledés:  s',
+  ['respawn_available_in'] = 'Újraéledés: %s',
   ['respawn_bleedout_in'] = 'Elfogsz vérezni  %s perc %s másodperclva...\n',
-  ['respawn_bleedout_prompt'] = 'Nyomd meg az  [E]mbot az újraéledéshez',
-  ['respawn_bleedout_fine'] = 'Újraéledéshez:  [E]',
-  ['respawn_bleedout_fine_msg'] = ' [Információ]:Ennyit fizettél  , hogy újraéledj',
+  ['respawn_bleedout_prompt'] = 'Nyomd meg az [E]mbot az újraéledéshez',
+  ['respawn_bleedout_fine'] = 'Újraéledéshez: [E]',
+  ['respawn_bleedout_fine_msg'] = '[Információ]:Ennyit fizettél, hogy újraéledj',
   ['distress_send'] = 'Nyomd meg a   gombot a segítségkéréshez',
   ['distress_sent'] = ' [Információ]:y civil értesítette az illetékes szervezetet!',
   -- Revive
   ['revive_help'] = 'újraéleszteni egy játékos',
   -- Item
-  ['used_medikit'] = ' [Információ]:használtál  1x Segélytáskát.',
-  ['used_bandage'] = ' [Információ]:használtál  1x Kötszert.',
-  ['not_enough_medikit'] = ' máció]:ncs nálad:  Defibrillátor.',
-  ['not_enough_bandage'] = ' máció]:ncs nálad:  Kötszer.',
+  ['used_medikit'] = ' [Információ]:használtál 1x segélytáskát.',
+  ['used_bandage'] = ' [Információ]:használtál 1x kötszert.',
+  ['not_enough_medikit'] = '[Információ]:ncs nálad: Defibrillátor.',
+  ['not_enough_bandage'] = '[Információ]:ncs nálad: Kötszer.',
   ['healed'] = ' [Információ]:ggyógyítottak!',
   -- Blips
   ['blip_hospital'] = 'Korház',

--- a/[esx_addons]/esx_ambulancejob/locales/nl.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/nl.lua
@@ -63,20 +63,20 @@ Locales['nl'] = {
   -- Phone
   ['alert_ambulance'] = 'alert Ambulance',
   -- Death
-  ['respawn_available_in'] = 'Respawn beschikbaar in  %s minuten en %s seconden',
-  ['respawn_bleedout_in'] = 'Je zal doodbloeden in  %s minuten %s seconden\n',
-  ['respawn_bleedout_prompt'] = 'Houd [ E] ingedrukt om te respawnen',
-  ['respawn_bleedout_fine'] = 'Houd [ E] ingedrukt om te respawnen voor €%s',
-  ['respawn_bleedout_fine_msg'] = 'Je hebt   betaald om te respawnen.',
-  ['distress_send'] = 'Druk op [~bs~] om een noodsignaal te verzenden',
+  ['respawn_available_in'] = 'Respawn beschikbaar in %s minuten en %s seconden',
+  ['respawn_bleedout_in'] = 'Je zal doodbloeden in %s minuten %s seconden\n',
+  ['respawn_bleedout_prompt'] = 'Houd [E] ingedrukt om te respawnen',
+  ['respawn_bleedout_fine'] = 'Houd [E] ingedrukt om te respawnen voor €%s',
+  ['respawn_bleedout_fine_msg'] = 'Je hebt €%s betaald om te respawnen.',
+  ['distress_send'] = 'Druk op [G] om een noodsignaal te verzenden',
   ['distress_sent'] = 'Noodsignaal verzonden naar alle beschikbare eenheden!',
   -- Revive
   ['revive_help'] = 'Revive een speler',
   -- Item
   ['used_medikit'] = 'Je hebt 1 spoedkoffer gebruikt',
   ['used_bandage'] = 'Je hebt 1 verbandkoffer gebruikt',
-  ['not_enough_medikit'] = 'Je hebt geen  spoedkoffer bij.',
-  ['not_enough_bandage'] = 'Je hebt geen  verbandkoffer bij.',
+  ['not_enough_medikit'] = 'Je hebt geen spoedkoffer bij.',
+  ['not_enough_bandage'] = 'Je hebt geen verbandkoffer bij.',
   ['healed'] = 'Je bent behandeld.',
   -- Blips
   ['blip_hospital'] = 'Ziekenhuis',

--- a/[esx_addons]/esx_ambulancejob/locales/pl.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/pl.lua
@@ -64,20 +64,20 @@ Locales['pl'] = {
   -- Phone
   ['alert_ambulance'] = 'wezwij ambulans',
   -- Death
-  ['respawn_available_in'] = 'respawn available in  %s minutes %s seconds',
-  ['respawn_bleedout_in'] = 'you will bleed out in  %s minutes %s seconds\n',
-  ['respawn_bleedout_prompt'] = 'hold [ E] to respawn',
-  ['respawn_bleedout_fine'] = 'hold [ E] to respawn for $%s',
-  ['respawn_bleedout_fine_msg'] = 'you paid   to respawn.',
-  ['distress_send'] = 'press [~bs~] to send distress signal',
+  ['respawn_available_in'] = 'respawn available in %s minutes %s seconds',
+  ['respawn_bleedout_in'] = 'you will bleed out in %s minutes %s seconds\n',
+  ['respawn_bleedout_prompt'] = 'hold [E] to respawn',
+  ['respawn_bleedout_fine'] = 'hold [E] to respawn for $%s',
+  ['respawn_bleedout_fine_msg'] = 'you paid $%s to respawn.',
+  ['distress_send'] = 'press [G] to send distress signal',
   ['distress_sent'] = 'distress signal has been sent to available units!',
   -- Revive
   ['revive_help'] = 'ożyw gracza',
   -- Item
-  ['used_medikit'] = 'użyłeś 1x Apteczki',
-  ['used_bandage'] = 'użyłeś 1x Bandaża',
-  ['not_enough_medikit'] = 'nie posiadasz  apteczki.',
-  ['not_enough_bandage'] = 'nie posiadasz  bandaża.',
+  ['used_medikit'] = 'użyłeś 1x apteczki',
+  ['used_bandage'] = 'użyłeś 1x bandaża',
+  ['not_enough_medikit'] = 'nie posiadasz apteczki.',
+  ['not_enough_bandage'] = 'nie posiadasz bandaża.',
   ['healed'] = 'zostałeś potraktowany',
   -- Blips
   ['blip_hospital'] = 'szpital',

--- a/[esx_addons]/esx_ambulancejob/locales/si.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/si.lua
@@ -69,7 +69,7 @@ Locales['si'] = {
   ['respawn_bleedout_prompt'] = "Držite [E], da se ponovno poženete",
   ['respawn_bleedout_fine'] = 'Držite [E], da se ponovno pojavite za $%s',
   ['respawn_bleedout_fine_msg'] = 'Plačali ste $%s za ponovni zagon.',
-  ['distress_send'] = 'Pritisnite [[E]za pošiljanje signala za pomoč',
+  ['distress_send'] = 'Pritisnite [G] za pošiljanje signala za pomoč',
   ['distress_sent'] = 'Signal v stiski je bil poslan razpoložljivim enotam!',
   -- Oživitev
   ['revive_help'] = 'oživi igralca',

--- a/[esx_addons]/esx_ambulancejob/locales/sv.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/sv.lua
@@ -64,20 +64,20 @@ Locales['sv'] = {
   -- Phone
   ['alert_ambulance'] = 'ambulanssamtal',
   -- Death
-  ['respawn_available_in'] = 'respawn tillgänglig om  %s:%s',
-  ['respawn_bleedout_in'] = 'du kommer att förblöda om  %s:%s\n',
-  ['respawn_bleedout_prompt'] = 'håll [ E] för att respawna',
-  ['respawn_bleedout_fine'] = 'håll [ E] för att respawna, kostar %s SEK',
-  ['respawn_bleedout_fine_msg'] = 'du betalade   för att respawna.',
+  ['respawn_available_in'] = 'respawn tillgänglig om %s:%s',
+  ['respawn_bleedout_in'] = 'du kommer att förblöda om %s:%s\n',
+  ['respawn_bleedout_prompt'] = 'håll [E] för att respawna',
+  ['respawn_bleedout_fine'] = 'håll [E] för att respawna, kostar %s SEK',
+  ['respawn_bleedout_fine_msg'] = 'du betalade %s för att respawna.',
   ['distress_send'] = 'tryck  [G] för att skicka nödsignal',
   ['distress_sent'] = 'nödsignal har skickats till samtliga enheter!',
   -- Revive
   ['revive_help'] = 'återuppliva en spelare',
   -- Item
-  ['used_medikit'] = 'du har använt 1x  Akutväska',
-  ['used_bandage'] = 'du har använt 1x  Bandage',
-  ['not_enough_medikit'] = 'du har ingen  Akutväska.',
-  ['not_enough_bandage'] = 'du har inget  Bandage.',
+  ['used_medikit'] = 'du har använt 1x akutväska',
+  ['used_bandage'] = 'du har använt 1x bandage',
+  ['not_enough_medikit'] = 'du har ingen akutväska.',
+  ['not_enough_bandage'] = 'du har inget bandage.',
   ['healed'] = 'dina skador har blivit behandlade.',
   -- Blips
   ['blip_hospital'] = 'sjukhus',

--- a/[esx_addons]/esx_ambulancejob/locales/tr.lua
+++ b/[esx_addons]/esx_ambulancejob/locales/tr.lua
@@ -63,12 +63,12 @@ Locales['tr'] = {
 	-- Phone
 	['alert_ambulance'] = 'hastane Acil Durum',
 	-- Death
-	['respawn_available_in'] = 'yeniden canlanmana  %s dakika %s saniye kaldı',
-	['respawn_bleedout_in'] = 'kanama  %s dakika %s saniye boyunca devam edecek\n',
-	['respawn_bleedout_prompt'] = 'yeniden canlanma için [ E] basılı tut',
-	['respawn_bleedout_fine'] = '%s lira karşılığında canlanma için [ E] basılı tut',
-	['respawn_bleedout_fine_msg'] = 'yeniden doğmak için   ödediniz.',
-	['distress_send'] = 'acile sinyal göndermek için [~bs~] basın',
+	['respawn_available_in'] = 'yeniden canlanmana %s dakika %s saniye kaldı',
+	['respawn_bleedout_in'] = 'kanama %s dakika %s saniye boyunca devam edecek\n',
+	['respawn_bleedout_prompt'] = 'yeniden canlanma için [E] basılı tut',
+	['respawn_bleedout_fine'] = '%s lira karşılığında canlanma için [E] basılı tut',
+	['respawn_bleedout_fine_msg'] = 'yeniden doğmak için %s ödediniz.',
+	['distress_send'] = 'acile sinyal göndermek için [G] basın',
 	['distress_sent'] = 'acil durum sinyali gönderildi!',
 	['revive_help'] = 'oyuncuyu canlandır',
 	-- Item


### PR DESCRIPTION
Removed some extra spacings, added amount of money to respawn_bleedout_fine_msg and corrected respawn key in distress_send.
In most of the variables invalid_amount the sentence is cut, someone who knows the respective language of each file would have to solve it.