### PR TITLE
fix:(esx_lscustoms) markers issue

### DIFF
--- a/[esx_addons]/esx_lscustom/client/main.lua
+++ b/[esx_addons]/esx_lscustom/client/main.lua
@@ -4,7 +4,7 @@ local lsMenuIsShowed, HintDisplayed, isInLSMarker = false, false, false
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(xPlayer)
     ESX.PlayerLoaded = true
-
+	ESX.PlayerData = xPlayer
     ESX.TriggerServerCallback('esx_lscustom:getVehiclesPrices', function(vehicles)
         Vehicles = vehicles
     end)


### PR DESCRIPTION
cannot use lscustom markers when you enable only for mechanic  and when on duty mechanic restart his game after loaded into game he was not able to use markers this will fix it