### PR TITLE
improve(client/main.lua): make sure this event dont call in client side

### DIFF
--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -13,8 +13,7 @@ CreateThread(function()
 	end
 end)
 
-RegisterNetEvent('esx:playerLoaded')
-AddEventHandler('esx:playerLoaded', function(xPlayer, isNew, skin)
+RegisterNetEvent('esx:playerLoaded', function(xPlayer, isNew, skin)
 	ESX.PlayerLoaded = true
 	ESX.PlayerData = xPlayer
 


### PR DESCRIPTION
When you want register net event trigger by server side only
you can use
RegisterNetEvent(eventName, function()
    print("hello")
end)

**should not be used**
RegisterNetEvent(eventName)
AddEventHander(eventName, function()
   print("hello world")
end)

![image](https://user-images.githubusercontent.com/61742272/184098002-a3686c2f-47d3-445d-a761-dcc16a185627.png)
other event. i recommanded refector, improve code if you have free time
Thanks a lot.😁