### PR TITLE
minor change: add support for skipping validation of single command arguments

### DIFF
--- a/[esx]/es_extended/server/commands.lua
+++ b/[esx]/es_extended/server/commands.lua
@@ -35,7 +35,7 @@ ESX.RegisterCommand({'cardel', 'dv'}, 'admin', function(xPlayer, args, showError
 		end
 	end
 end, false, {help = _U('command_cardel'), validate = false, arguments = {
-	{name = 'radius',validate = false, help = _U('command_cardel_radius'), type = 'string'}
+	{name = 'radius',validate = false, help = _U('command_cardel_radius'), type = 'number'}
 }})
 
 ESX.RegisterCommand('setaccountmoney', 'admin', function(xPlayer, args, showError)

--- a/[esx]/es_extended/server/functions.lua
+++ b/[esx]/es_extended/server/functions.lua
@@ -112,6 +112,10 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
 								newArgs[v.name] = args[k]
 							end
 						end
+				
+						if v.validate ~= false then
+							error = nil
+						end
 
 						if error then break end
 					end


### PR DESCRIPTION
It's cleaner than forcing stuff to an argument type that just skips validation altogether.
And will be useful in the future for new commands utilising the validate variable.