### PR TITLE
Fix(esx/main): throwables, parachutes and gas canisters are not removed by the server

### DIFF
--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -421,8 +421,23 @@ end
 
 function StartServerSyncLoops()
 	if not Config.OxInventory then
-			-- keep track of ammo
+			-- keep track of weapons in loadout
+			CreateThread(function()
+				while ESX.PlayerLoaded do
+					for i, weapon in ipairs(ESX.GetPlayerData().loadout) do
+						local playerHasWeapon = HasPedGotWeapon(ESX.GetPlayerData().ped, GetHashKey(weapon.name), false)
 
+						if not playerHasWeapon then
+							TriggerServerEvent('esx:removeWeapon', weapon.name)
+						end
+					end 
+
+
+					Wait(1000)
+				end
+			end)
+
+			-- keep track of ammo
 			CreateThread(function()
 					local currentWeapon = {Ammo = 0}
 					while ESX.PlayerLoaded do

--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -232,6 +232,11 @@ if not Config.OxInventory then
 		end
 	end)
 
+	RegisterNetEvent('esx:syncLoadout')
+	AddEventHandler('esx:syncLoadout', function(loadout)
+		ESX.PlayerData.loadout = loadout
+	end)
+
 	RegisterNetEvent('esx:addWeapon')
 	AddEventHandler('esx:addWeapon', function(weapon, ammo)
 		GiveWeaponToPed(ESX.PlayerData.ped, GetHashKey(weapon), ammo, false, false)

--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -339,6 +339,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 			self.triggerEvent('esx:addWeapon', weaponName, ammo)
 			self.triggerEvent('esx:addInventoryItem', weaponLabel, false, true)
+			self.triggerEvent('esx:syncLoadout', self.loadout)
 		end
 	end
 
@@ -353,6 +354,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 					self.loadout[loadoutNum].components[#self.loadout[loadoutNum].components + 1] = weaponComponent
 					self.triggerEvent('esx:addWeaponComponent', weaponName, weaponComponent)
 					self.triggerEvent('esx:addInventoryItem', component.label, false, true)
+					self.triggerEvent('esx:syncLoadout', self.loadout)
 				end
 			end
 		end
@@ -387,6 +389,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 				self.loadout[loadoutNum].tintIndex = weaponTintIndex
 				self.triggerEvent('esx:setWeaponTint', weaponName, weaponTintIndex)
 				self.triggerEvent('esx:addInventoryItem', weaponObject.tints[weaponTintIndex], false, true)
+				self.triggerEvent('esx:syncLoadout', self.loadout)
 			end
 		end
 	end
@@ -420,6 +423,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		if weaponLabel then
 			self.triggerEvent('esx:removeWeapon', weaponName)
 			self.triggerEvent('esx:removeInventoryItem', weaponLabel, false, true)
+			self.triggerEvent('esx:syncLoadout', self.loadout)
 		end
 	end
 
@@ -440,6 +444,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 					self.triggerEvent('esx:removeWeaponComponent', weaponName, weaponComponent)
 					self.triggerEvent('esx:removeInventoryItem', component.label, false, true)
+					self.triggerEvent('esx:syncLoadout', self.loadout)
 				end
 			end
 		end

--- a/[esx]/es_extended/server/main.lua
+++ b/[esx]/es_extended/server/main.lua
@@ -389,6 +389,15 @@ AddEventHandler('esx:updateCoords', function(coords)
 end)
 
 if not Config.OxInventory then
+    RegisterNetEvent('esx:removeWeapon')
+    AddEventHandler('esx:removeWeapon', function(weaponName)
+        local xPlayer = ESX.GetPlayerFromId(source)
+
+        if xPlayer then
+            xPlayer.removeWeapon(weaponName)
+        end
+    end)
+
     RegisterNetEvent('esx:updateWeaponAmmo')
     AddEventHandler('esx:updateWeaponAmmo', function(weaponName, ammoCount)
         local xPlayer = ESX.GetPlayerFromId(source)


### PR DESCRIPTION
(Issue #370)

The server persists incorrect client loadouts whenever a weapon was removed by native GTA features, such as using your parachute. GTA removes certain weapons whenever they're used. The server is not getting informed about that removal.

To fix this issue, the client needs to be synchronized with the servers state about it's loadout, so it is able to periodically check if the items that are supposed to be there are actually there. If not, due to e.g. GTA removed a weapon, the server will be informed and the players server-loadout will be adjusted accordingly 