### PR TITLE
fix(es_extended/client/functions.lua) Livery Mod Get/Set-VehicleProperties

### DIFF
--- a/[esx]/es_extended/client/functions.lua
+++ b/[esx]/es_extended/client/functions.lua
@@ -823,7 +823,7 @@ function ESX.Game.GetVehicleProperties(vehicle)
             modTrimB = GetVehicleMod(vehicle, 44),
             modTank = GetVehicleMod(vehicle, 45),
             modDoorR = GetVehicleMod(vehicle, 47),
-            modLivery = GetVehicleLivery(vehicle),
+            modLivery = GetVehicleMod(vehicle, 48),
             modLightbar = GetVehicleMod(vehicle, 49)
         }
     else
@@ -1045,7 +1045,7 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
         end
 
         if props.modLivery then
-            SetVehicleLivery(vehicle, props.modLivery)
+            SetVehicleMod(vehicle, 48, props.modLivery, false)
         end
 
         if props.windowsBroken then


### PR DESCRIPTION
Natives "GetVehicleLivery" and "SetVehicleLivery" doesn't work anymore.
Replaced broken natives in "ESX.Game.GetVehicleProperties" and "ESX.Game.SetVehicleProperties" with "GetVehicleMod" and "SetVehicleMod" with modType 48

https://forum.cfx.re/t/setvehiclelivery-not-working-even-when-setting-setvehiclemodkit-to-0