### PR TITLE
refactor: esx_ambulance/client/job.lua esx:setJob fixed

### DIFF
--- a/[esx_addons]/esx_ambulancejob/client/job.lua
+++ b/[esx_addons]/esx_ambulancejob/client/job.lua
@@ -499,7 +499,7 @@ end)
 
 RegisterNetEvent('esx:setJob')
 AddEventHandler('esx:setJob', function(job)
-	if isOnDuty and job ~= 'ambulance' then
+	if isOnDuty and job.name ~= 'ambulance' then
 		for playerId,v in pairs(deadPlayerBlips) do
 			if Config.Debug then 
 				print("[INFO] removing dead player blip |" .. tostring(playerId))


### PR DESCRIPTION
The first parameter in the event esx:setJob was used in the wrong way, job is returning a table however we want job.name to get the name of the job, if we check <a href="https://github.com/esx-framework/esx-legacy/blob/main/esx_example/client/main.lua">esx_example</a> it's used in the same way