### PR TITLE
fix(esx/server): use protected calls for Item Callbacks

### DIFF
--- a/[esx]/es_extended/server/functions.lua
+++ b/[esx]/es_extended/server/functions.lua
@@ -311,8 +311,14 @@ end
 
 function ESX.UseItem(source, item, ...)
 	if ESX.Items[item] then
-		if Core.UsableItemsCallbacks[item] then
-			Core.UsableItemsCallbacks[item](source, item, ...)
+		local itemCallback = Core.UsableItemsCallbacks[item]
+
+		if itemCallback then
+			local success, result = pcall(itemCallback, source, item, ...)
+
+			if not success then
+				return result and print(result) or print(('[^3WARNING^7] An error occured when using item ^5"%s"^7! This was not caused by ESX.'):format(item))
+			end
 		end
 	else
 		print(('[^3WARNING^7] Item ^5"%s"^7 was used but does not exist!'):format(item))


### PR DESCRIPTION
If the script that registered an item callback has stopped and ESX.UseItem is used, an error will occur (but seemingly with no message??).
```
[  script:es_extended] SCRIPT ERROR: citizen:/scripting/lua/scheduler.lua:479: attempt to concatenate a nil value (local 'err')
[  script:es_extended] > cb (@ox_inventory/server.lua:242)
[  script:es_extended] > handler (@ox_lib/callback/server.lua:59)
```

```
[ citizen-server-impl] Stopping resource esx_mechanicjob
[  script:es_extended] [WARNING] An error occured when using item "carokit"! This was not caused by ESX.
```