### PR TITLE
Removed esx_phone Check

### DIFF
--- a/[esx_addons]/esx_ambulancejob/server/main.lua
+++ b/[esx_addons]/esx_ambulancejob/server/main.lua
@@ -1,8 +1,6 @@
 local playersHealing, deadPlayers = {}, {}
 
-if GetResourceState("esx_phone") ~= 'missing' then
 TriggerEvent('esx_phone:registerNumber', 'ambulance', _U('alert_ambulance'), true, true)
-end
 
 if GetResourceState("esx_society") ~= 'missing' then
 TriggerEvent('esx_society:registerSociety', 'ambulance', 'Ambulance', 'society_ambulance', 'society_ambulance', 'society_ambulance', {type = 'public'})


### PR DESCRIPTION
I removed the esx_phone Check, otherwise the number dont gets registered for the re-ignited gcphone and make the edits for the Distress not working.