### PR TITLE
fix(es_extended): onesync.lua coords variables

### DIFF
--- a/[esx]/es_extended/server/onesync.lua
+++ b/[esx]/es_extended/server/onesync.lua
@@ -65,7 +65,7 @@ end
 function ESX.OneSync.SpawnVehicle(model, coords, heading, autoMobile, Properties, cb)
 	model = type(model) == 'string' and joaat(model) or model
 	Properties = Properties or {}
-	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
+	local coords = type(coords) == "vector3" and coords or vector3(coords.x, coords.y, coords.z)
 	if type(autoMobile) ~= 'boolean' then
 		return
 	end
@@ -86,7 +86,7 @@ end
 ---@param cb function
 function ESX.OneSync.SpawnObject(model, coords, heading, cb)
 	if type(model) == 'string' then model = joaat(model) end
-	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
+	local coords = type(coords) == "vector3" and coords or vector3(coords.x, coords.y, coords.z)
 	CreateThread(function()
 		local entity = CreateObject(model, coords, true, true)
 		while not DoesEntityExist(entity) do Wait(50) end


### PR DESCRIPTION
Fixes the Invalid Lua type error.
```
SCRIPT ERROR: Invalid Lua type in __data
> fn (@es_extended/server/onesync.lua:91)
```