### PR TITLE
feat(es_extended/classes/player.lua): add esx:setGroup event

### DIFF
--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -75,9 +75,14 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.setGroup(newGroup)
+		local old = self.group
+
 		ExecuteCommand(('remove_principal identifier.%s group.%s'):format(self.license, self.group))
 		self.group = newGroup
 		ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
+
+		self.triggerEvent('esx:setGroup', newGroup, old)
+		TriggerEvent('esx:setGroup', self.source, newGroup, old)
 	end
 
 	function self.getGroup()


### PR DESCRIPTION
Title has everything
On the server side, xPlayer can be used instead of serverId, I am waiting for suggestions.

## Snippets
### Server
```lua
AddEventHandler("esx:setGroup", function(serverId, group, oldGroup)
print(serverId, group, oldGroup)
end) 
```
### Client
```lua
RegisterNetEvent("esx:setGroup", function(group, oldGroup)
print(group, oldGroup)
end)
```