### PR TITLE
refactor(es_extended/server/classes/player.lua): xPlayer.canCarryItem - Error handling - Item not found

### DIFF
--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -300,10 +300,14 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.canCarryItem(name, count, metadata)
-		local currentWeight, itemWeight = self.weight, ESX.Items[name].weight
-		local newWeight = currentWeight + (itemWeight * count)
+        if ESX.Items[name] then
+            local currentWeight, itemWeight = self.weight, ESX.Items[name].weight
+            local newWeight = currentWeight + (itemWeight * count)
 
-		return newWeight <= self.maxWeight
+            return newWeight <= self.maxWeight
+        else
+            print(('[^3WARNING^7] Item ^5"%s"^7 was used but does not exist!'):format(name))
+        end
 	end
 
 	function self.canSwapItem(firstItem, firstItemCount, testItem, testItemCount)


### PR DESCRIPTION
Recently came across a guy in my community who tried to use this function, but he got this error. 
![Error Image](https://cdn.discordapp.com/attachments/806888340116078612/1029384700755722290/unknown.png)

Obviously, this is not that helpful and I would presume that it is not the first time someone passed an unknown item into this function and got this error.

> Added a check to display a more precise error message