### PR TITLE
fix(esx_menu_default) Menu Refresh Discriminator

### DIFF
--- a/[esx]/es_extended/client/functions.lua
+++ b/[esx]/es_extended/client/functions.lua
@@ -330,7 +330,7 @@ function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, c
     end
 
     menu.refresh = function()
-        ESX.UI.Menu.RegisteredTypes[type].open(namespace, name, menu.data)
+        ESX.UI.Menu.RegisteredTypes[type].open(namespace, name, menu.data, true)
     end
 
     menu.setElement = function(i, key, val)

--- a/[esx]/esx_menu_default/client/main.lua
+++ b/[esx]/esx_menu_default/client/main.lua
@@ -1,8 +1,8 @@
 local GUI, MenuType, OpenedMenus = {}, 'default', 0
 GUI.Time = 0
 
-local function openMenu(namespace, name, data)
-    OpenedMenus += 1
+local function openMenu(namespace, name, data, refresh)
+    if not refresh then OpenedMenus += 1 end
     SendNUIMessage({
         action = 'openMenu',
         namespace = namespace,

--- a/[esx]/esx_menu_dialog/client/main.lua
+++ b/[esx]/esx_menu_dialog/client/main.lua
@@ -82,8 +82,7 @@ end)
 
 CreateThread(function()
 	while true do
-		Wait(0)
-
+		local sleep = 1500
 		if ESX.Table.SizeOf(OpenedMenus) > 0 then
 			DisableControlAction(0, 1,   true) -- LookLeftRight
 			DisableControlAction(0, 2,   true) -- LookUpDown
@@ -94,8 +93,8 @@ CreateThread(function()
 			DisableControlAction(0, 15, true) -- WeaponWheelPrev
 			DisableControlAction(0, 16, true) -- SelectNextWeapon
 			DisableControlAction(0, 17, true) -- SelectPrevWeapon
-		else
-			Wait(500)
+			sleep = 0
 		end
+		Wait(sleep)
 	end
 end)


### PR DESCRIPTION
When esx_menu_default was refreshed, counted like a new menu (OpenedMenus added 1)
This prevented the loop going to sleep when the menu should be closed.
On resources like esx_skin using esx_menu_default, when you change any option, it counts a new opened menu wont let the thread going to sleep.