### PR TITLE
refactor(esx_lscustom) : fix free tuning glitch

### DIFF
--- a/[esx_addons]/esx_lscustom/client/main.lua
+++ b/[esx_addons]/esx_lscustom/client/main.lua
@@ -17,6 +17,15 @@ AddEventHandler('esx_lscustom:installMod', function()
     TriggerServerEvent('esx_lscustom:refreshOwnedVehicle', myCar)
 end)
 
+RegisterNetEvent('esx_lscustom:restoreMods', function(netId, props)
+    local xVehicle = NetworkGetEntityFromNetworkId(netId)
+    if props ~= nil then
+        if DoesEntityExist(xVehicle) then
+            ESX.Game.SetVehicleProperties(xVehicle, props)
+        end
+    end
+end)
+
 RegisterNetEvent('esx_lscustom:cancelInstallMod')
 AddEventHandler('esx_lscustom:cancelInstallMod', function()
     local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
@@ -51,7 +60,6 @@ AddEventHandler('onResourceStop', function(resource)
 	end
 end)
 
-
 function OpenLSMenu(elems, menuName, menuTitle, parent)
     ESX.UI.Menu.Open('default', GetCurrentResourceName(), menuName, {
         title = menuTitle,
@@ -82,7 +90,7 @@ function OpenLSMenu(elems, menuName, menuTitle, parent)
                             break
                         end
                     end
-
+                    
                     if isRimMod then
                         price = math.floor(vehiclePrice * data.current.price / 100)
                         TriggerServerEvent('esx_lscustom:buyMod', price)
@@ -120,6 +128,7 @@ function OpenLSMenu(elems, menuName, menuTitle, parent)
             lsMenuIsShowed = false
             local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
             FreezeEntityPosition(vehicle, false)
+            TriggerServerEvent('esx_lscustom:stopModing', myCar.plate)
             myCar = {}
         end
     end, function(data, menu) -- on change
@@ -170,7 +179,6 @@ function GetAction(data)
     local playerPed = PlayerPedId()
     local vehicle = GetVehiclePedIsIn(playerPed, false)
     local currentMods = ESX.Game.GetVehicleProperties(vehicle)
-
     if data.value == 'modSpeakers' or data.value == 'modTrunk' or data.value == 'modHydrolic' or data.value ==
         'modEngineBlock' or data.value == 'modAirFilter' or data.value == 'modStruts' or data.value == 'modTank' then
         SetVehicleDoorOpen(vehicle, 4, false)
@@ -503,6 +511,9 @@ CreateThread(function()
                                 local vehicle = GetVehiclePedIsIn(playerPed, false)
                                 FreezeEntityPosition(vehicle, true)
                                 myCar = ESX.Game.GetVehicleProperties(vehicle)
+                                
+                                local netId = NetworkGetNetworkIdFromEntity(vehicle)
+                                TriggerServerEvent('esx_lscustom:startModing', myCar, netId)
 
                                 ESX.UI.Menu.CloseAll()
                                 GetAction({

--- a/[esx_addons]/esx_lscustom/server/main.lua
+++ b/[esx_addons]/esx_lscustom/server/main.lua
@@ -1,4 +1,40 @@
 local Vehicles
+local Customs = {}
+
+RegisterNetEvent('esx_lscustom:startModing', function(props, netId)
+	local src = tostring(source)
+	if Customs[src] then
+		Customs[src][props.plate] = {props = props, netId = netId}
+	else
+		Customs[src] = {}
+		Customs[src][props.plate] = {props = props, netId = netId}
+	end
+end)
+
+RegisterNetEvent('esx_lscustom:stopModing', function(plate)
+	local src = tostring(source)
+	if Customs[src] then
+		Customs[src][tostring(plate)] = nil
+	end
+end)
+
+AddEventHandler('esx:playerDropped', function(src)
+	src = tostring(src)
+	local playersCount = #ESX.GetPlayers()
+	if Customs[src] then
+		for k,v in pairs(Customs[src]) do
+			local entity = NetworkGetEntityFromNetworkId(v.netId)
+			if DoesEntityExist(entity) then
+				if players > 0 then
+					TriggerClientEvent('esx_lscustom:restoreMods', -1, v.netId, v.props)
+				else
+					DeleteEntity(entity)
+				end
+			end
+		end
+		Customs[src] = nil
+	end
+end)
 
 RegisterServerEvent('esx_lscustom:buyMod')
 AddEventHandler('esx_lscustom:buyMod', function(price)
@@ -41,9 +77,9 @@ AddEventHandler('esx_lscustom:refreshOwnedVehicle', function(vehicleProps)
 	function(result)
 		if result then
 			local vehicle = json.decode(result.vehicle)
-
 			if vehicleProps.model == vehicle.model then
 				MySQL.update('UPDATE owned_vehicles SET vehicle = ? WHERE plate = ?', {json.encode(vehicleProps), vehicleProps.plate})
+				Customs[tostring(source)][tostring(vehicleProps.plate)].props = props
 			else
 				print(('[^3WARNING^7] Player ^5%s^7 Attempted To upgrade with mismatching vehicle model'):format(xPlayer.source))
 			end


### PR DESCRIPTION
save props and net id in object for source id and vehicle plate .
update props when buy any mod ( when save in database ) .
remove vehicle object from source object when parent menu closed .
mod restore when server players count more than 0 .
vehicle entity remove from server when players count are 0 .

Thanks to @iSentrie  for help in testing resource

Issue :   #289 
