### PR TITLE
fix(es_extended): GetVehicleProperties custom xenon color

### DIFF
--- a/[esx]/es_extended/client/functions.lua
+++ b/[esx]/es_extended/client/functions.lua
@@ -676,9 +676,9 @@ function ESX.Game.GetVehicleProperties(vehicle)
             customPrimaryColor = {r, g, b}
         end
 
-        local customXenonColorR, customXenonColorG, customXenonColorB = GetVehicleXenonLightsCustomColor(vehicle)
+        local hasCustomXenonColor, customXenonColorR, customXenonColorG, customXenonColorB = GetVehicleXenonLightsCustomColor(vehicle)
         local customXenonColor = nil
-        if customXenonColorR and customXenonColorG and customXenonColorB then 
+        if hasCustomXenonColor then 
             customXenonColor = {customXenonColorR, customXenonColorG, customXenonColorB}
         end
         


### PR DESCRIPTION
The first return parameter of GetVehicleXenonLightsCustomColor is a boolean indicating if the vehicle has custom color.