### PR TITLE
Update setjob command to use lowercase

### DIFF
--- a/[esx]/es_extended/server/commands.lua
+++ b/[esx]/es_extended/server/commands.lua
@@ -7,8 +7,9 @@ end, false, {help = TranslateCap('command_setcoords'), validate = true, argument
 }})
 
 ESX.RegisterCommand('setjob', 'admin', function(xPlayer, args, showError)
-	if ESX.DoesJobExist(args.job, args.grade) then
-		args.playerId.setJob(args.job, args.grade)
+	local Jobs_Lower = string.lower(args.job)
+	if ESX.DoesJobExist(Jobs_Lower, args.grade) then
+		args.playerId.setJob(Jobs_Lower, args.grade)
 	else
 		showError(TranslateCap('command_setjob_invalid'))
 	end


### PR DESCRIPTION
using lowercase on the job argument to find a job that may have been typed correctly but with a upper case letter at the start eg "Mechanic" would result in no results even though "mechanic" exists.