### PR TITLE
Add Config.BossGrades

### DIFF
--- a/[esx_addons]/esx_society/config.lua
+++ b/[esx_addons]/esx_society/config.lua
@@ -3,3 +3,6 @@ Config = {}
 Config.Locale = GetConvar('esx:locale', 'en')
 Config.EnableESXIdentity = true
 Config.MaxSalary = 3500
+Config.BossGrades = {
+    'boss'
+}

--- a/[esx_addons]/esx_society/server/main.lua
+++ b/[esx_addons]/esx_society/server/main.lua
@@ -1,6 +1,15 @@
 local Jobs = {}
 local RegisteredSocieties = {}
 
+function IsGradeBoss(grade)
+	for k,v in ipairs(Config.BossGrades) do
+		if grade == v then
+			return true
+		end
+	end
+	return false
+end
+
 function GetSociety(name)
 	for i=1, #RegisteredSocieties, 1 do
 		if RegisteredSocieties[i].name == name then
@@ -289,7 +298,7 @@ end)
 
 ESX.RegisterServerCallback('esx_society:setJob', function(source, cb, identifier, job, grade, actionType)
 	local xPlayer = ESX.GetPlayerFromId(source)
-	local isBoss = xPlayer.job.grade_name == 'boss'
+	local isBoss = IsGradeBoss(xPlayer.job.grade_name)
 	local xTarget = ESX.GetPlayerFromIdentifier(identifier)
 
 	if isBoss then
@@ -325,7 +334,7 @@ end)
 ESX.RegisterServerCallback('esx_society:setJobSalary', function(source, cb, job, grade, salary)
 	local xPlayer = ESX.GetPlayerFromId(source)
 
-	if xPlayer.job.name == job and xPlayer.job.grade_name == 'boss' then
+	if xPlayer.job.name == job and IsGradeBoss(xPlayer.job.grade_name) then
 		if salary <= Config.MaxSalary then
 			MySQL.update('UPDATE job_grades SET salary = ? WHERE job_name = ? AND grade = ?', {salary, job, grade},
 			function(rowsChanged)
@@ -354,7 +363,7 @@ end)
 ESX.RegisterServerCallback('esx_society:setJobLabel', function(source, cb, job, grade, label)
 	local xPlayer = ESX.GetPlayerFromId(source)
 
-	if xPlayer.job.name == job and xPlayer.job.grade_name == 'boss' then
+	if xPlayer.job.name == job and IsGradeBoss(xPlayer.job.grade_name) then
 			MySQL.update('UPDATE job_grades SET label = ? WHERE job_name = ? AND grade = ?', {label, job, grade},
 			function(rowsChanged)
 				Jobs[job].grades[tostring(grade)].label = label
@@ -419,7 +428,7 @@ end)
 function isPlayerBoss(playerId, job)
 	local xPlayer = ESX.GetPlayerFromId(playerId)
 
-	if xPlayer.job.name == job and xPlayer.job.grade_name == 'boss' then
+	if xPlayer.job.name == job and IsGradeBoss(xPlayer.job.grade_name) then
 		return true
 	else
 		print(('esx_society: %s attempted open a society boss menu!'):format(xPlayer.identifier))


### PR DESCRIPTION
Added the option to allow other grades than 'boss' to access the boss menu.
Could for example be used to allow an player with an 'underboss' grade to access the boss menu.