### PR TITLE
refactor(es_extended): Server sided Coord Saving + fix spawning of invalid vehicles

### DIFF
--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -438,27 +438,6 @@ function StartServerSyncLoops()
 					end
 			end)
 	end
-
-	-- sync current player coords with server
-	CreateThread(function()
-		local previousCoords = vector3(ESX.PlayerData.coords.x, ESX.PlayerData.coords.y, ESX.PlayerData.coords.z)
-
-		while ESX.PlayerLoaded do
-			local playerPed = PlayerPedId()
-			if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
-
-			if DoesEntityExist(ESX.PlayerData.ped) then
-				local playerCoords = GetEntityCoords(ESX.PlayerData.ped)
-				local distance = #(playerCoords - previousCoords)
-
-				if distance > 1 then
-					previousCoords = playerCoords
-					TriggerServerEvent('esx:updateCoords')
-				end
-			end
-			Wait(1500)
-		end
-	end)
 end
 
 if not Config.OxInventory and Config.EnableDefaultInventory then

--- a/[esx]/es_extended/client/main.lua
+++ b/[esx]/es_extended/client/main.lua
@@ -690,28 +690,33 @@ AddEventHandler("esx:freezePlayer", function(input)
 end)
 
 RegisterNetEvent("esx:GetVehicleType", function(Model, Request)
+	local ReturnedType = "automobile"
 	local Model = Model
-	local VehicleType = GetVehicleClassFromName(Model)
-	local type = "automobile"
-	if VehicleType == 15 then
-		type = "heli"
-	elseif VehicleType == 16 then
-		type = "plane"
-	elseif VehicleType == 14 then
-		type = "boat"
-	elseif VehicleType == 11 then
-		type = "trailer"
-	elseif VehicleType == 21 then
-		type = "train"
-	elseif VehicleType == 13 or VehicleType == 8 then
-		type = "bike"
-	end
-	if Model == `submersible` or Model == `submersible2` then
-		type = "submarine"
-	end
-	TriggerServerEvent("esx:ReturnVehicleType", type, Request)
-end)
+	local IsValidModel = IsModelInCdimage(Model)
+	if IsValidModel == true or IsValidModel == 1 then
+		local VehicleType = GetVehicleClassFromName(Model)
 
+		if VehicleType == 15 then
+			ReturnedType = "heli"
+		elseif VehicleType == 16 then
+			ReturnedType = "plane"
+		elseif VehicleType == 14 then
+			ReturnedType = "boat"
+		elseif VehicleType == 11 then
+			ReturnedType = "trailer"
+		elseif VehicleType == 21 then
+			ReturnedType = "train"
+		elseif VehicleType == 13 or VehicleType == 8 then
+			ReturnedType = "bike"
+		end
+		if Model == `submersible` or Model == `submersible2` then
+			ReturnedType = "submarine"
+		end
+	else 
+		ReturnedType = false
+	end
+	TriggerServerEvent("esx:ReturnVehicleType", ReturnedType, Request)
+end)
 
 local DoNotUse = {
 	'essentialmode',

--- a/[esx]/es_extended/server/classes/player.lua
+++ b/[esx]/es_extended/server/classes/player.lua
@@ -1,3 +1,9 @@
+local SetTimeout = SetTimeout
+local GetPlayerPed = GetPlayerPed
+local DoesEntityExist = DoesEntityExist
+local GetEntityCoords = GetEntityCoords
+local GetEntityHeading = GetEntityHeading
+
 function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, weight, job, loadout, name, coords)
 	local targetOverrides = Config.PlayerFunctionOverride and Core.PlayerFunctionOverrides[Config.PlayerFunctionOverride] or {}
 	
@@ -31,7 +37,6 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.setCoords(coords)
-		self.updateCoords(coords)
 		local Ped = GetPlayerPed(self.source)
 		local vector = type(coords) == "vector4" and coords or type(coords) == "vector3" and vector4(coords, 0.0) or
 		vec(coords.x, coords.y, coords.z, coords.heading or 0.0)
@@ -40,10 +45,23 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.updateCoords()
-		local Ped = GetPlayerPed(self.source)
-		local coords = GetEntityCoords(Ped)
-		local heading = GetEntityHeading(Ped)
-		self.coords = {x = ESX.Math.Round(coords.x, 1), y = ESX.Math.Round(coords.y, 1), z = ESX.Math.Round(coords.z, 1), heading = ESX.Math.Round(heading or 0.0, 1)}
+		SetTimeout(1000,function()
+			local Ped = GetPlayerPed(self.source)
+			if DoesEntityExist(Ped) then
+				local coords = GetEntityCoords(Ped)
+				local distance = #(coords - vector3(self.coords.x, self.coords.y, self.coords.z))
+				if distance > 1.5 then
+					local heading = GetEntityHeading(Ped)
+					self.coords = {
+						x = coords.x,
+						y = coords.y, 
+						z = coords.z, 
+						heading = heading or 0.0
+					}
+				end
+			end
+			self.updateCoords()
+		end)
 	end
 
 	function self.getCoords(vector)

--- a/[esx]/es_extended/server/main.lua
+++ b/[esx]/es_extended/server/main.lua
@@ -317,7 +317,7 @@ function loadESXPlayer(identifier, playerId, isNew)
   else
     exports.ox_inventory:setPlayerInventory(xPlayer, userData.inventory)
   end
-
+  xPlayer.updateCoords()
   xPlayer.triggerEvent('esx:registerSuggestions', Core.RegisteredCommands)
   print(('[^2INFO^0] Player ^5"%s"^0 has connected to the server. ID: ^5%s^7'):format(xPlayer.getName(), playerId))
 end

--- a/[esx]/es_extended/server/main.lua
+++ b/[esx]/es_extended/server/main.lua
@@ -359,16 +359,6 @@ AddEventHandler('esx:playerLogout', function(playerId, cb)
   TriggerClientEvent("esx:onPlayerLogout", playerId)
 end)
 
-RegisterNetEvent('esx:updateCoords')
-AddEventHandler('esx:updateCoords', function()
-  local source = source
-  local xPlayer = ESX.GetPlayerFromId(source)
-
-  if xPlayer then
-    xPlayer.updateCoords()
-  end
-end)
-
 if not Config.OxInventory then
   RegisterNetEvent('esx:updateWeaponAmmo')
   AddEventHandler('esx:updateWeaponAmmo', function(weaponName, ammoCount)

--- a/[esx]/es_extended/server/onesync.lua
+++ b/[esx]/es_extended/server/onesync.lua
@@ -61,23 +61,29 @@ end
 ---@param heading number
 ---@param Properties table
 ---@param cb function
-function ESX.OneSync.SpawnVehicle(model, coords, heading, Properties, cb)
-    model = type(model) == 'string' and joaat(model) or model
-    Properties = Properties or {}
-    local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-    TriggerClientEvent("esx:requestModel", -1, model)
-    CreateThread(function()
-        local xPlayer = ESX.OneSync.GetClosestPlayer(vector, 200)
-        ESX.GetVehicleType(model, xPlayer.id, function(Type)
-            local SpawnedEntity = CreateVehicleServerSetter(model, Type, vector, heading)
-            Wait(250)
-            local NetworkId = NetworkGetNetworkIdFromEntity(SpawnedEntity)
-            Properties.NetId = NetworkId
-            Entity(SpawnedEntity).state:set('VehicleProperties', Properties, true)
-            cb(NetworkId)
-        end)
-    end)
-end
+	function ESX.OneSync.SpawnVehicle(model, coords, heading, Properties, cb)
+		local veh_model = type(model) == 'string' and joaat(model) or model
+		Properties = Properties or {}
+		local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
+		TriggerClientEvent("esx:requestModel", -1, model)
+		CreateThread(function()
+			local xPlayer = ESX.OneSync.GetClosestPlayer(vector, 300)
+			ESX.GetVehicleType(veh_model, xPlayer.id, function(Type)
+				if Type then
+					local SpawnedEntity = CreateVehicleServerSetter(veh_model, Type, vector, heading)
+					local NetworkId = NetworkGetNetworkIdFromEntity(SpawnedEntity)
+					while not DoesEntityExist(SpawnedEntity) do 
+						Wait(100)
+					end
+					Properties.NetId = NetworkId
+					Entity(SpawnedEntity).state:set('VehicleProperties', Properties, true)
+					cb(NetworkId)
+				else 
+					print(('[^1ERROR^7] Tried to spawn invalid vehicle - ^5%s^7!'):format(model))
+				end
+			end)
+		end)
+	end
 
 
 ---@param model number|string


### PR DESCRIPTION
this is a threadless design that allows both xPlayer.coords and xPlayer.getCoords to correctly function, aswell as removing the need for the client to trigger a server event this is once again, a change that **requires** Onesync **infinity**