### PR TITLE
feat: add canClose to context menu

### DIFF
--- a/[esx]/esx_context/index.html
+++ b/[esx]/esx_context/index.html
@@ -352,8 +352,11 @@
 		}
 
 		function Close() {
-			$.post(`https://${GetParentResourceName()}/closed`)
-			Closed()
+			$.post(`https://${GetParentResourceName()}/closed`,(retVal)=>{
+				if(retVal){
+					Closed()
+				}
+			})
 		}
 
 		window.addEventListener("message", (e) => {

--- a/[esx]/esx_context/main.lua
+++ b/[esx]/esx_context/main.lua
@@ -12,10 +12,11 @@ function Post(fn,...)
 	})
 end
 
-function Open(position,eles,onSelect,onClose)
+function Open(position,eles,onSelect,onClose,canClose)
 	activeMenu = {
 		position = position,
 		eles = eles,
+		canClose = canClose,
 		onSelect = onSelect,
 		onClose = onClose
 	}
@@ -74,11 +75,11 @@ end)
 -- NUI Callbacks
 -- [ closed | selected | changed ]
 
-RegisterNUICallback("closed",function()
-	if not activeMenu then
-		return
+RegisterNUICallback("closed",function(data,cb)
+	if not activeMenu or (activeMenu and not activeMenu.canClose) then
+		return cb(false)
 	end
-
+	cb(true)
 	Closed()
 end)
 

--- a/[esx]/esx_multicharacter/client/main.lua
+++ b/[esx]/esx_multicharacter/client/main.lua
@@ -164,7 +164,7 @@ if ESX.GetConfig().Multichar then
 			elseif Action.action == "return" then
 				SelectCharacterMenu(Characters, slots)
 			end
-		end, nil, true)
+		end, nil, false)
 	end
 
 	function SelectCharacterMenu(Characters, slots)
@@ -212,7 +212,7 @@ if ESX.GetConfig().Multichar then
 				SetPedAoBlobRendering(playerPed, true)
 				ResetEntityAlpha(playerPed)
 			end
-		end, nil, true)
+		end, nil, false)
 	end
 	RegisterNetEvent('esx_multicharacter:SetupUI')
 	AddEventHandler('esx_multicharacter:SetupUI', function(data, slots)


### PR DESCRIPTION
Added canClose to context menu so that players can't close the menu by pressing ESC instead must be force closed in the code.