### PR TITLE
fix(esx_lscustom): Added 5th engine level

### DIFF
--- a/[esx_addons]/esx_lscustom/config.lua
+++ b/[esx_addons]/esx_lscustom/config.lua
@@ -483,13 +483,13 @@ Config.Menus = {
 		label = TranslateCap('engine'),
 		parent = 'upgrades',
 		modType = 11,
-		price = {13.95, 32.56, 65.12, 139.53}
+		price = {13.95, 27.9, 55.8, 111.6, 139.53}
 	},
 	modBrakes = {
 		label = TranslateCap('brakes'),
 		parent = 'upgrades',
 		modType = 12,
-		price = {4.65, 9.3, 18.6, 13.95}
+		price = {4.65, 9.3, 13.95, 18.6}
 	},
 	modTransmission = {
 		label = TranslateCap('transmission'),


### PR DESCRIPTION
Fix for vehicles that has 5 engine upgrades, example `shinobi` Prevents errors.

Also adjusted prices, swapped places brake prices and a little adjusted engine prices, which looks too